### PR TITLE
Add CSV import feature for rate tables DRO-1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -179,7 +179,7 @@ Metrics/PerceivedComplexity:
   Enabled: false
 Naming/BlockForwarding:
   Enabled: true
-Naming/PredicateName:
+Naming/PredicatePrefix:
   Enabled: false
 Naming/VariableNumber:
   Enabled: false

--- a/CSV_IMPORT_GUIDE.md
+++ b/CSV_IMPORT_GUIDE.md
@@ -1,0 +1,143 @@
+# CSV Import Guide for Rate Tables
+
+## Overview
+
+The CSV import feature allows you to bulk import shipping rates instead of entering them one-by-one. This is particularly useful when you need to configure rates for multiple regions, shipping methods, or weight ranges.
+
+## Accessing the Import Feature
+
+1. Navigate to **Rate Tables** in the application
+2. Click the **"Import CSV"** button (green button)
+3. Upload your CSV file
+4. Review results and any errors
+
+## CSV File Format
+
+### Required Columns
+
+Your CSV file **must** include these columns (order doesn't matter):
+
+| Column | Type | Description | Example |
+|--------|------|-------------|---------|
+| `shipping_method` | String | Name of existing shipping method | Express Shipping |
+| `country` | String (2 chars) | ISO 2-letter country code | US, CA, MX |
+| `region` | String | State/province **code** (not full name) | CA, NY, ON, BC |
+| `min_range_lbs` | Decimal | Minimum weight in pounds | 0, 5.5, 10 |
+| `max_range_lbs` | Decimal | Maximum weight in pounds | 5, 10.5, 25 |
+| `flat_rate` | Decimal | Shipping cost in dollars | 9.99, 15.50 |
+| `min_charge` | Decimal | Minimum charge in dollars | 5.00, 10.00 |
+
+### Important Notes
+
+- **Region codes, not names**: Use `CA` (not California), `NY` (not New York), `ON` (not Ontario)
+- **Country codes**: Must be exactly 2 characters (US, CA, MX, GB, etc.)
+- **First rate must start at 0**: For each unique shipping_method + country + region combination, the first rate must have `min_range_lbs = 0`
+- **No overlapping ranges**: Weight ranges cannot overlap for the same location and shipping method
+- **Shipping method must exist**: The shipping method name must match an existing method in your account
+
+## Example CSV File
+
+```csv
+shipping_method,country,region,min_range_lbs,max_range_lbs,flat_rate,min_charge
+Express Shipping,US,CA,0,5,9.99,5.00
+Express Shipping,US,CA,5,10,14.99,10.00
+Express Shipping,US,CA,10,25,24.99,15.00
+Express Shipping,US,NY,0,5,12.99,8.00
+Express Shipping,US,NY,5,10,17.99,12.00
+Standard Shipping,US,CA,0,10,5.99,3.00
+Standard Shipping,US,CA,10,25,9.99,5.00
+Standard Shipping,CA,ON,0,10,15.99,10.00
+Standard Shipping,CA,BC,0,10,18.99,12.00
+```
+
+## Common Region Codes
+
+### United States (US)
+- CA - California
+- NY - New York
+- TX - Texas
+- FL - Florida
+- IL - Illinois
+- etc. (use 2-letter state abbreviations)
+
+### Canada (CA)
+- ON - Ontario
+- BC - British Columbia
+- QC - Quebec
+- AB - Alberta
+- MB - Manitoba
+- etc. (use 2-letter province abbreviations)
+
+### Other Countries
+Check the specific country's standard region/state codes.
+
+## Validation Rules
+
+The import process validates each row and will report errors for:
+
+1. **Missing shipping method**: Shipping method doesn't exist
+2. **Invalid country code**: Not exactly 2 characters
+3. **Missing region**: Region field is blank
+4. **Invalid weight ranges**: 
+   - min_range_lbs is negative
+   - max_range_lbs is less than or equal to min_range_lbs
+   - First rate for a location doesn't start at 0
+   - Ranges overlap with existing rates
+5. **Invalid pricing**: 
+   - flat_rate or min_charge is negative
+
+## Import Results
+
+After uploading your CSV:
+
+- **Success**: All rates imported successfully
+- **Partial Success**: Some rates imported, some had errors (errors shown with row numbers)
+- **Failure**: No rates imported (errors shown)
+
+## Tips
+
+1. **Download the sample CSV** from the import page to see the correct format
+2. **Test with a small file first** (2-3 rows) to verify your format
+3. **Check your shipping method names** - they must match exactly (case-sensitive)
+4. **Use codes, not full names** for regions
+5. **Organize by location** - group all rates for the same location together
+6. **Sequential weight ranges** - ensure ranges don't overlap and start at 0
+
+## Troubleshooting
+
+### "Shipping method not found"
+- Verify the shipping method name matches exactly (including spaces and capitalization)
+- Create the shipping method first if it doesn't exist
+
+### "Country is the wrong length"
+- Use 2-letter codes only (US, not USA or United States)
+
+### "Min_range_lbs must be 0 for the first rate"
+- Each new location (country + region + shipping method combo) must start with min_range_lbs = 0
+
+### "Weight range overlaps"
+- Check for existing rates in the database
+- Ensure no overlapping ranges in your CSV file
+- Each rate must have distinct, non-overlapping weight ranges
+
+## Example Use Cases
+
+### Setting up tiered pricing for multiple states
+```csv
+shipping_method,country,region,min_range_lbs,max_range_lbs,flat_rate,min_charge
+Express Shipping,US,CA,0,5,9.99,5.00
+Express Shipping,US,CA,5,15,14.99,10.00
+Express Shipping,US,CA,15,50,24.99,15.00
+Express Shipping,US,NY,0,5,9.99,5.00
+Express Shipping,US,NY,5,15,14.99,10.00
+Express Shipping,US,NY,15,50,24.99,15.00
+```
+
+### Multiple shipping methods for same region
+```csv
+shipping_method,country,region,min_range_lbs,max_range_lbs,flat_rate,min_charge
+Express Shipping,US,CA,0,10,15.99,10.00
+Standard Shipping,US,CA,0,10,8.99,5.00
+Economy Shipping,US,CA,0,10,4.99,3.00
+```
+

--- a/app/services/rate_csv_import_service.rb
+++ b/app/services/rate_csv_import_service.rb
@@ -43,10 +43,16 @@ private
   def valid_file_type?
     return false unless file.respond_to?(:path) || file.respond_to?(:read)
 
+    # Check file extension first if available
+    if file.respond_to?(:original_filename) && file.original_filename.present?
+      return false unless File.extname(file.original_filename).downcase == ".csv"
+    elsif file.respond_to?(:path)
+      return false unless File.extname(file.path).downcase == ".csv"
+    end
+
+    # Then check content type if available
     if file.respond_to?(:content_type)
       file.content_type.in?([ "text/csv", "text/plain", "application/vnd.ms-excel" ])
-    elsif file.respond_to?(:path)
-      File.extname(file.path).downcase == ".csv"
     else
       true
     end
@@ -141,7 +147,7 @@ private
       success: true,
       message: "Imported #{@success_count} rate(s) with #{row_errors.count} error(s)",
       imported_count: @success_count,
-      errors: row_errors,
+      row_errors: row_errors,
     }
   end
 

--- a/app/services/rate_csv_import_service.rb
+++ b/app/services/rate_csv_import_service.rb
@@ -1,0 +1,158 @@
+require "csv"
+
+class RateCsvImportService
+  attr_reader :company, :file, :errors, :success_count, :row_errors
+
+  def initialize(company:, file:)
+    @company = company
+    @file = file
+    @errors = []
+    @row_errors = []
+    @success_count = 0
+  end
+
+  def call
+    return failure("No file provided") unless file.present?
+    return failure("Invalid file type. Please upload a CSV file.") unless valid_file_type?
+
+    csv_data = read_csv_file
+    return failure("Unable to read CSV file") unless csv_data
+
+    validate_headers(csv_data)
+    return failure("Invalid CSV headers") if errors.any?
+
+    import_rates(csv_data)
+
+    if @success_count > 0 && row_errors.empty?
+      success
+    elsif @success_count > 0 && row_errors.any?
+      partial_success
+    else
+      failure("No rates were imported")
+    end
+  end
+
+  def success?
+    errors.empty? && row_errors.empty? && @success_count > 0
+  end
+
+private
+
+  REQUIRED_HEADERS = %w[shipping_method country region min_range_lbs max_range_lbs flat_rate min_charge].freeze
+
+  def valid_file_type?
+    return false unless file.respond_to?(:path) || file.respond_to?(:read)
+
+    if file.respond_to?(:content_type)
+      file.content_type.in?([ "text/csv", "text/plain", "application/vnd.ms-excel" ])
+    elsif file.respond_to?(:path)
+      File.extname(file.path).downcase == ".csv"
+    else
+      true
+    end
+  end
+
+  def read_csv_file
+    content = file.respond_to?(:read) ? file.read : File.read(file.path)
+    CSV.parse(content, headers: true, header_converters: :symbol)
+  rescue CSV::MalformedCSVError => e
+    @errors << "Malformed CSV file: #{e.message}"
+    nil
+  rescue StandardError => e
+    @errors << "Error reading CSV file: #{e.message}"
+    nil
+  end
+
+  def validate_headers(csv_data)
+    return if csv_data.headers.nil?
+
+    missing_headers = REQUIRED_HEADERS.map(&:to_sym) - csv_data.headers
+    if missing_headers.any?
+      @errors << "Missing required columns: #{missing_headers.join(', ')}"
+    end
+  end
+
+  def import_rates(csv_data)
+    csv_data.each_with_index do |row, index|
+      row_number = index + 2 # +2 because index is 0-based and we skip header row
+
+      begin
+        import_rate_row(row, row_number)
+      rescue StandardError => e
+        @row_errors << { row: row_number, errors: [ e.message ] }
+      end
+    end
+  end
+
+  def import_rate_row(row, row_number)
+    # Skip empty rows
+    return if row.to_h.values.all?(&:blank?)
+
+    shipping_option = find_shipping_option(row[:shipping_method], row_number)
+    return unless shipping_option
+
+    rate = shipping_option.rates.new(
+      country: row[:country]&.strip&.upcase,
+      region: row[:region]&.strip,
+      min_range_lbs: row[:min_range_lbs],
+      max_range_lbs: row[:max_range_lbs],
+      flat_rate: row[:flat_rate],
+      min_charge: row[:min_charge]
+    )
+
+    if rate.valid?
+      rate.save!
+      @success_count += 1
+    else
+      @row_errors << {
+        row: row_number,
+        data: row.to_h,
+        errors: rate.errors.full_messages,
+      }
+    end
+  end
+
+  def find_shipping_option(name, row_number)
+    return nil if name.blank?
+
+    shipping_option = company.shipping_options.find_by(name: name.strip)
+
+    unless shipping_option
+      @row_errors << {
+        row: row_number,
+        errors: [ "Shipping method '#{name}' not found" ],
+      }
+      return nil
+    end
+
+    shipping_option
+  end
+
+  def success
+    {
+      success: true,
+      message: "Successfully imported #{@success_count} rate(s)",
+      imported_count: @success_count,
+    }
+  end
+
+  def partial_success
+    {
+      success: true,
+      message: "Imported #{@success_count} rate(s) with #{row_errors.count} error(s)",
+      imported_count: @success_count,
+      errors: row_errors,
+    }
+  end
+
+  def failure(message)
+    @errors << message unless @errors.include?(message)
+    {
+      success: false,
+      message: message,
+      errors: @errors,
+      row_errors: @row_errors,
+    }
+  end
+end
+

--- a/app/services/rate_csv_import_service.rb
+++ b/app/services/rate_csv_import_service.rb
@@ -155,4 +155,3 @@ private
     }
   end
 end
-

--- a/app/views/rates/_rate_tables.html.erb
+++ b/app/views/rates/_rate_tables.html.erb
@@ -19,9 +19,16 @@
         <p class="text-gray-600">Configure pricing for different shipping methods and regions</p>
       </div>
       <% if @shipping_options.any? %>
-        <%= link_to new_rate_table_path, class: "inline-flex items-center px-6 py-3 bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-700 hover:to-blue-800 text-white font-medium rounded-xl shadow-lg hover:shadow-xl transition-all duration-200 transform hover:scale-105", data: { turbo_frame: "_top" } do %>
-          Add Rate Table
-        <% end %>
+        <div class="flex items-center gap-3">
+          <%= link_to import_rate_tables_path, class: "inline-flex items-center px-6 py-3 bg-gradient-to-r from-green-600 to-green-700 hover:from-green-700 hover:to-green-800 text-white font-medium rounded-xl shadow-lg hover:shadow-xl transition-all duration-200 transform hover:scale-105", data: { turbo_frame: "_top" } do %>
+            <i class="fa-solid fa-file-import mr-2"></i>
+            Import CSV
+          <% end %>
+          <%= link_to new_rate_table_path, class: "inline-flex items-center px-6 py-3 bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-700 hover:to-blue-800 text-white font-medium rounded-xl shadow-lg hover:shadow-xl transition-all duration-200 transform hover:scale-105", data: { turbo_frame: "_top" } do %>
+            <i class="fa-solid fa-plus mr-2"></i>
+            Add Rate Table
+          <% end %>
+        </div>
       <% end %>
     </div>
   <% end %>
@@ -97,9 +104,14 @@
           </div>
           <h3 class="mt-2 text-sm font-medium text-gray-900">No rate tables found</h3>
           <p class="mt-1 text-sm text-gray-500">Create shipping methods and add rate tables to get started.</p>
-          <div class="mt-6">
+          <div class="mt-6 flex gap-3 justify-center">
             <% if @shipping_options.any? %>
+              <%= link_to import_rate_tables_path, class: "inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-green-600 hover:bg-green-700 transition-colors duration-200", data: { turbo_frame: "_top" } do %>
+                <i class="fa-solid fa-file-import mr-2"></i>
+                Import CSV
+              <% end %>
               <%= link_to new_rate_table_path, class: "inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 transition-colors duration-200", data: { turbo_frame: "_top" } do %>
+                <i class="fa-solid fa-plus mr-2"></i>
                 Add Rate Table
               <% end %>
             <% else %>

--- a/app/views/rates/import.html.erb
+++ b/app/views/rates/import.html.erb
@@ -1,0 +1,163 @@
+<div class="bg-white rounded-2xl shadow-sm border border-gray-100 p-8 max-w-4xl mx-auto">
+  <div class="mb-8">
+    <h1 class="text-2xl font-bold text-gray-900 mb-2">Import Rate Tables from CSV</h1>
+    <p class="text-gray-600">Upload a CSV file to bulk import shipping rates for your methods.</p>
+  </div>
+
+  <% if flash[:alert] || flash[:errors] || flash[:row_errors] %>
+    <div class="bg-red-50 border border-red-200 rounded-xl p-4 mb-6">
+      <div class="flex">
+        <div class="flex-shrink-0">
+          <i class="fa-solid fa-exclamation-triangle text-red-400"></i>
+        </div>
+        <div class="ml-3 flex-1">
+          <% if flash[:alert] %>
+            <h3 class="text-sm font-medium text-red-800 mb-2">
+              <%= flash[:alert] %>
+            </h3>
+          <% end %>
+          
+          <% if flash[:errors].present? %>
+            <div class="mt-2 text-sm text-red-700">
+              <ul class="list-disc list-inside space-y-1">
+                <% flash[:errors].each do |error| %>
+                  <li><%= error %></li>
+                <% end %>
+              </ul>
+            </div>
+          <% end %>
+
+          <% if flash[:row_errors].present? %>
+            <div class="mt-3">
+              <h4 class="text-sm font-medium text-red-800 mb-2">Row Errors:</h4>
+              <div class="max-h-64 overflow-y-auto">
+                <% flash[:row_errors].each do |row_error| %>
+                  <div class="mb-2 p-2 bg-red-100 rounded">
+                    <strong>Row <%= row_error[:row] %>:</strong>
+                    <ul class="list-disc list-inside ml-4">
+                      <% row_error[:errors].each do |error| %>
+                        <li><%= error %></li>
+                      <% end %>
+                    </ul>
+                    <% if row_error[:data] %>
+                      <div class="text-xs mt-1 text-red-600">
+                        Data: <%= row_error[:data].inspect %>
+                      </div>
+                    <% end %>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  <% end %>
+
+  <!-- CSV Format Instructions -->
+  <div class="bg-blue-50 border border-blue-200 rounded-xl p-6 mb-6">
+    <h3 class="text-lg font-semibold text-blue-900 mb-3 flex items-center">
+      <i class="fa-solid fa-info-circle mr-2"></i>
+      CSV Format Requirements
+    </h3>
+    <div class="text-sm text-blue-800 space-y-2">
+      <p>Your CSV file must include the following columns (in any order):</p>
+      <ul class="list-disc list-inside ml-4 space-y-1">
+        <li><strong>shipping_method</strong> - Name of an existing shipping method</li>
+        <li><strong>country</strong> - 2-letter country code (e.g., US, CA, MX)</li>
+        <li><strong>region</strong> - State/province code (e.g., CA, NY, ON, BC)</li>
+        <li><strong>min_range_lbs</strong> - Minimum weight in pounds (must start at 0 for each location)</li>
+        <li><strong>max_range_lbs</strong> - Maximum weight in pounds</li>
+        <li><strong>flat_rate</strong> - Shipping cost in dollars</li>
+        <li><strong>min_charge</strong> - Minimum charge in dollars</li>
+      </ul>
+    </div>
+  </div>
+
+  <!-- Example CSV -->
+  <div class="bg-gray-50 border border-gray-200 rounded-xl p-6 mb-6">
+    <h3 class="text-lg font-semibold text-gray-900 mb-3 flex items-center">
+      <i class="fa-solid fa-file-csv mr-2"></i>
+      Example CSV Format
+    </h3>
+    <div class="bg-white p-4 rounded border border-gray-300 overflow-x-auto">
+      <pre class="text-xs font-mono text-gray-800">shipping_method,country,region,min_range_lbs,max_range_lbs,flat_rate,min_charge
+Express Shipping,US,CA,0,5,9.99,5.00
+Express Shipping,US,CA,5,10,14.99,10.00
+Express Shipping,US,NY,0,5,12.99,8.00
+Standard Shipping,CA,ON,0,10,15.99,10.00</pre>
+    </div>
+    <div class="mt-3">
+      <button onclick="downloadSampleCSV()" class="text-sm text-blue-600 hover:text-blue-800 font-medium">
+        <i class="fa-solid fa-download mr-1"></i>
+        Download Sample CSV
+      </button>
+    </div>
+  </div>
+
+  <!-- Upload Form -->
+  <%= form_with url: process_import_rate_tables_path, multipart: true, local: true, class: "space-y-6" do |form| %>
+    <div>
+      <label class="block text-sm font-medium text-gray-700 mb-2">
+        Select CSV File
+      </label>
+      <div class="mt-1 flex justify-center px-6 pt-5 pb-6 border-2 border-gray-300 border-dashed rounded-xl hover:border-blue-400 transition-colors">
+        <div class="space-y-1 text-center">
+          <i class="fa-solid fa-cloud-arrow-up text-4xl text-gray-400 mb-3"></i>
+          <div class="flex text-sm text-gray-600">
+            <label for="csv_file" class="relative cursor-pointer bg-white rounded-md font-medium text-blue-600 hover:text-blue-500 focus-within:outline-none">
+              <span>Upload a file</span>
+              <%= file_field_tag :csv_file, accept: ".csv", class: "sr-only", id: "csv_file", required: true %>
+            </label>
+            <p class="pl-1">or drag and drop</p>
+          </div>
+          <p class="text-xs text-gray-500">CSV files only</p>
+        </div>
+      </div>
+      <div id="file-name" class="mt-2 text-sm text-gray-600"></div>
+    </div>
+
+    <div class="flex justify-end space-x-4 pt-6">
+      <%= link_to "Cancel", rate_tables_path, class: "px-6 py-3 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-lg transition-colors duration-200", data: { turbo_frame: "_top" } %>
+      <%= form.submit "Import Rates", class: "px-6 py-3 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors duration-200" %>
+    </div>
+  <% end %>
+</div>
+
+<script>
+// Show selected file name
+document.getElementById('csv_file').addEventListener('change', function(e) {
+  const fileName = e.target.files[0]?.name;
+  const fileNameDisplay = document.getElementById('file-name');
+  if (fileName) {
+    fileNameDisplay.textContent = 'Selected file: ' + fileName;
+    fileNameDisplay.classList.add('font-medium', 'text-blue-600');
+  }
+});
+
+// Download sample CSV
+function downloadSampleCSV() {
+  const csvContent = `shipping_method,country,region,min_range_lbs,max_range_lbs,flat_rate,min_charge
+Express Shipping,US,CA,0,5,9.99,5.00
+Express Shipping,US,CA,5,10,14.99,10.00
+Express Shipping,US,CA,10,25,24.99,15.00
+Express Shipping,US,NY,0,5,12.99,8.00
+Express Shipping,US,NY,5,10,17.99,12.00
+Standard Shipping,US,CA,0,10,5.99,3.00
+Standard Shipping,US,CA,10,25,9.99,5.00
+Standard Shipping,CA,ON,0,10,15.99,10.00
+Standard Shipping,CA,ON,10,25,22.99,15.00
+Standard Shipping,CA,BC,0,10,18.99,12.00`;
+
+  const blob = new Blob([csvContent], { type: 'text/csv' });
+  const url = window.URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.setAttribute('hidden', '');
+  a.setAttribute('href', url);
+  a.setAttribute('download', 'rate_import_sample.csv');
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+}
+</script>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,5 +30,10 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :rates, except: [ :show ], as: :rate_tables
+  resources :rates, except: [ :show ], as: :rate_tables do
+    collection do
+      get :import
+      post :process_import
+    end
+  end
 end

--- a/test/services/rate_csv_import_service_test.rb
+++ b/test/services/rate_csv_import_service_test.rb
@@ -319,4 +319,3 @@ private
     Rack::Test::UploadedFile.new(file.path, "text/csv", original_filename: "test.csv")
   end
 end
-

--- a/test/services/rate_csv_import_service_test.rb
+++ b/test/services/rate_csv_import_service_test.rb
@@ -1,0 +1,322 @@
+require "test_helper"
+
+class RateCsvImportServiceTest < ActiveSupport::TestCase
+  def setup
+    @company = companies(:acme)
+    @shipping_option = shipping_options(:express_shipping)
+  end
+
+  test "should successfully import valid CSV file" do
+    csv_content = <<~CSV
+      shipping_method,country,region,min_range_lbs,max_range_lbs,flat_rate,min_charge
+      Express Shipping,US,CA,0,5,9.99,5.00
+      Express Shipping,US,NY,0,10,12.99,8.00
+    CSV
+
+    file = create_csv_file(csv_content)
+    service = RateCsvImportService.new(company: @company, file: file)
+
+    result = service.call
+
+    assert result[:success]
+    assert_equal 2, result[:imported_count]
+    assert_equal "Successfully imported 2 rate(s)", result[:message]
+    assert_equal 2, service.success_count
+  end
+
+  test "should return error when no file provided" do
+    service = RateCsvImportService.new(company: @company, file: nil)
+
+    result = service.call
+
+    assert_not result[:success]
+    assert_includes result[:message], "No file provided"
+  end
+
+  test "should return error for invalid file type" do
+    file = Rack::Test::UploadedFile.new(StringIO.new("not a csv"), "text/plain", original_filename: "test.txt")
+    service = RateCsvImportService.new(company: @company, file: file)
+
+    result = service.call
+
+    assert_not result[:success]
+    assert_includes result[:message], "Invalid file type"
+  end
+
+  test "should return error for missing required headers" do
+    csv_content = <<~CSV
+      shipping_method,country,min_range_lbs,max_range_lbs,flat_rate
+      Express Shipping,US,0,5,9.99
+    CSV
+
+    file = create_csv_file(csv_content)
+    service = RateCsvImportService.new(company: @company, file: file)
+
+    result = service.call
+
+    assert_not result[:success]
+    assert_includes result[:message], "Invalid CSV headers"
+    assert_includes result[:errors].first, "Missing required columns"
+  end
+
+  test "should handle malformed CSV file" do
+    csv_content = "shipping_method,country,region\nExpress Shipping,US"
+    file = create_csv_file(csv_content)
+    service = RateCsvImportService.new(company: @company, file: file)
+
+    result = service.call
+
+    # CSV parsing will handle this, but we should get some kind of result
+    assert result
+  end
+
+  test "should skip empty rows" do
+    csv_content = <<~CSV
+      shipping_method,country,region,min_range_lbs,max_range_lbs,flat_rate,min_charge
+      Express Shipping,US,CA,0,5,9.99,5.00
+      ,,,,,,
+      Express Shipping,US,NY,0,10,12.99,8.00
+    CSV
+
+    file = create_csv_file(csv_content)
+    service = RateCsvImportService.new(company: @company, file: file)
+
+    result = service.call
+
+    assert result[:success]
+    assert_equal 2, result[:imported_count]
+  end
+
+  test "should return row errors for invalid data" do
+    csv_content = <<~CSV
+      shipping_method,country,region,min_range_lbs,max_range_lbs,flat_rate,min_charge
+      Express Shipping,US,CA,0,5,9.99,5.00
+      Express Shipping,INVALID,CA,0,5,9.99,5.00
+      Express Shipping,US,NY,10,5,9.99,5.00
+    CSV
+
+    file = create_csv_file(csv_content)
+    service = RateCsvImportService.new(company: @company, file: file)
+
+    result = service.call
+
+    assert result[:success]
+    assert_equal 1, result[:imported_count]
+    assert result[:row_errors].present?
+    assert_equal 2, result[:row_errors].count
+  end
+
+  test "should return error for non-existent shipping method" do
+    csv_content = <<~CSV
+      shipping_method,country,region,min_range_lbs,max_range_lbs,flat_rate,min_charge
+      Non Existent Method,US,CA,0,5,9.99,5.00
+    CSV
+
+    file = create_csv_file(csv_content)
+    service = RateCsvImportService.new(company: @company, file: file)
+
+    result = service.call
+
+    assert_not result[:success]
+    assert result[:row_errors].present?
+    assert_includes result[:row_errors].first[:errors].first, "Shipping method 'Non Existent Method' not found"
+  end
+
+  test "should validate country code is 2 characters" do
+    csv_content = <<~CSV
+      shipping_method,country,region,min_range_lbs,max_range_lbs,flat_rate,min_charge
+      Express Shipping,USA,CA,0,5,9.99,5.00
+    CSV
+
+    file = create_csv_file(csv_content)
+    service = RateCsvImportService.new(company: @company, file: file)
+
+    result = service.call
+
+    assert_not result[:success]
+    assert result[:row_errors].present?
+    assert_includes result[:row_errors].first[:errors].join, "wrong length"
+  end
+
+  test "should validate region is present" do
+    csv_content = <<~CSV
+      shipping_method,country,region,min_range_lbs,max_range_lbs,flat_rate,min_charge
+      Express Shipping,US,,0,5,9.99,5.00
+    CSV
+
+    file = create_csv_file(csv_content)
+    service = RateCsvImportService.new(company: @company, file: file)
+
+    result = service.call
+
+    assert_not result[:success]
+    assert result[:row_errors].present?
+    assert_includes result[:row_errors].first[:errors].join, "can't be blank"
+  end
+
+  test "should validate min_range_lbs is greater than or equal to 0" do
+    csv_content = <<~CSV
+      shipping_method,country,region,min_range_lbs,max_range_lbs,flat_rate,min_charge
+      Express Shipping,US,CA,-1,5,9.99,5.00
+    CSV
+
+    file = create_csv_file(csv_content)
+    service = RateCsvImportService.new(company: @company, file: file)
+
+    result = service.call
+
+    assert_not result[:success]
+    assert result[:row_errors].present?
+    assert_includes result[:row_errors].first[:errors].join, "greater than or equal to 0"
+  end
+
+  test "should validate max_range_lbs is greater than min_range_lbs" do
+    csv_content = <<~CSV
+      shipping_method,country,region,min_range_lbs,max_range_lbs,flat_rate,min_charge
+      Express Shipping,US,CA,10,5,9.99,5.00
+    CSV
+
+    file = create_csv_file(csv_content)
+    service = RateCsvImportService.new(company: @company, file: file)
+
+    result = service.call
+
+    assert_not result[:success]
+    assert result[:row_errors].present?
+    assert_includes result[:row_errors].first[:errors].join, "must be greater than min_range_lbs"
+  end
+
+  test "should validate first rate for location must start at 0" do
+    csv_content = <<~CSV
+      shipping_method,country,region,min_range_lbs,max_range_lbs,flat_rate,min_charge
+      Express Shipping,US,FL,5,10,9.99,5.00
+    CSV
+
+    file = create_csv_file(csv_content)
+    service = RateCsvImportService.new(company: @company, file: file)
+
+    result = service.call
+
+    assert_not result[:success]
+    assert result[:row_errors].present?
+    assert_includes result[:row_errors].first[:errors].join, "must be 0 for the first rate"
+  end
+
+  test "should normalize country code to uppercase" do
+    csv_content = <<~CSV
+      shipping_method,country,region,min_range_lbs,max_range_lbs,flat_rate,min_charge
+      Express Shipping,us,CA,0,5,9.99,5.00
+    CSV
+
+    file = create_csv_file(csv_content)
+    service = RateCsvImportService.new(company: @company, file: file)
+
+    result = service.call
+
+    assert result[:success]
+    assert_equal 1, result[:imported_count]
+
+    rate = @shipping_option.rates.last
+    assert_equal "US", rate.country
+  end
+
+  test "should trim whitespace from values" do
+    csv_content = <<~CSV
+      shipping_method,country,region,min_range_lbs,max_range_lbs,flat_rate,min_charge
+      Express Shipping ,  US  , CA ,0,5,9.99,5.00
+    CSV
+
+    file = create_csv_file(csv_content)
+    service = RateCsvImportService.new(company: @company, file: file)
+
+    result = service.call
+
+    assert result[:success]
+    assert_equal 1, result[:imported_count]
+
+    rate = @shipping_option.rates.last
+    assert_equal "US", rate.country
+    assert_equal "CA", rate.region
+  end
+
+  test "should import multiple rates for same shipping option and location" do
+    csv_content = <<~CSV
+      shipping_method,country,region,min_range_lbs,max_range_lbs,flat_rate,min_charge
+      Express Shipping,US,CA,0,5,9.99,5.00
+      Express Shipping,US,CA,5,10,14.99,10.00
+      Express Shipping,US,CA,10,25,24.99,15.00
+    CSV
+
+    file = create_csv_file(csv_content)
+    service = RateCsvImportService.new(company: @company, file: file)
+
+    result = service.call
+
+    assert result[:success]
+    assert_equal 3, result[:imported_count]
+
+    rates = @shipping_option.rates.where(country: "US", region: "CA").order(:min_range_lbs)
+    assert_equal 3, rates.count
+    assert_equal 0, rates.first.min_range_lbs
+    assert_equal 5, rates.second.min_range_lbs
+    assert_equal 10, rates.third.min_range_lbs
+  end
+
+  test "should detect overlapping weight ranges" do
+    # Create first rate
+    @shipping_option.rates.create!(
+      country: "US",
+      region: "TX",
+      min_range_lbs: 0,
+      max_range_lbs: 10,
+      flat_rate: 10.00,
+      min_charge: 5.00
+    )
+
+    # Try to import overlapping rate
+    csv_content = <<~CSV
+      shipping_method,country,region,min_range_lbs,max_range_lbs,flat_rate,min_charge
+      Express Shipping,US,TX,5,15,14.99,10.00
+    CSV
+
+    file = create_csv_file(csv_content)
+    service = RateCsvImportService.new(company: @company, file: file)
+
+    result = service.call
+
+    assert_not result[:success]
+    assert result[:row_errors].present?
+    assert_includes result[:row_errors].first[:errors].join, "Weight range overlaps"
+  end
+
+  test "should return partial success when some rows succeed and some fail" do
+    csv_content = <<~CSV
+      shipping_method,country,region,min_range_lbs,max_range_lbs,flat_rate,min_charge
+      Express Shipping,US,CA,0,5,9.99,5.00
+      Non Existent Method,US,NY,0,5,9.99,5.00
+      Express Shipping,US,TX,0,10,12.99,8.00
+    CSV
+
+    file = create_csv_file(csv_content)
+    service = RateCsvImportService.new(company: @company, file: file)
+
+    result = service.call
+
+    assert result[:success]
+    assert_equal 2, result[:imported_count]
+    assert result[:row_errors].present?
+    assert_equal 1, result[:row_errors].count
+    assert_includes result[:message], "with"
+    assert_includes result[:message], "error"
+  end
+
+private
+
+  def create_csv_file(content)
+    file = Tempfile.new([ "test", ".csv" ])
+    file.write(content)
+    file.rewind
+    Rack::Test::UploadedFile.new(file.path, "text/csv", original_filename: "test.csv")
+  end
+end
+


### PR DESCRIPTION
- Add RateCsvImportService with comprehensive validation
- Add import and process_import actions to RatesController
- Create CSV upload view with drag-and-drop support
- Add import routes (GET /rates/import and POST /rates/process_import)
- Update rate tables UI with Import CSV button
- Add 18 comprehensive test cases for CSV import
- Include CSV_IMPORT_GUIDE.md with examples and troubleshooting

Features:
- Bulk import shipping rates from CSV
- Row-by-row validation with detailed error reporting
- Supports partial imports (some rows succeed, some fail)
- Auto-normalizes data (uppercase country codes, trim whitespace)
- Sample CSV download in UI
- Validates all Rate model constraints