### PR TITLE
Make region optional for country-level rates DRO-1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,9 @@ jobs:
       - name: Build assets
         run: yarn build
 
+      - name: Build Vite assets for test environment
+        run: bin/vite build --mode test
+
       - name: Run JavaScript tests
         run: yarn test
 

--- a/CSV_IMPORT_GUIDE.md
+++ b/CSV_IMPORT_GUIDE.md
@@ -21,7 +21,7 @@ Your CSV file **must** include these columns (order doesn't matter):
 |--------|------|-------------|---------|
 | `shipping_method` | String | Name of existing shipping method | Express Shipping |
 | `country` | String (2 chars) | ISO 2-letter country code | US, CA, MX |
-| `region` | String | State/province **code** (not full name) | CA, NY, ON, BC |
+| `region` | String (optional) | State/province **code** (leave blank for country-level rates) | CA, NY, ON, BC or blank |
 | `min_range_lbs` | Decimal | Minimum weight in pounds | 0, 5.5, 10 |
 | `max_range_lbs` | Decimal | Maximum weight in pounds | 5, 10.5, 25 |
 | `flat_rate` | Decimal | Shipping cost in dollars | 9.99, 15.50 |
@@ -29,7 +29,8 @@ Your CSV file **must** include these columns (order doesn't matter):
 
 ### Important Notes
 
-- **Region codes, not names**: Use `CA` (not California), `NY` (not New York), `ON` (not Ontario)
+- **Region is optional**: Leave region blank for country-level rates, or specify region codes for region-specific pricing
+- **Region codes, not names**: When specified, use codes like `CA` (not California), `NY` (not New York), `ON` (not Ontario)
 - **Country codes**: Must be exactly 2 characters (US, CA, MX, GB, etc.)
 - **First rate must start at 0**: For each unique shipping_method + country + region combination, the first rate must have `min_range_lbs = 0`
 - **No overlapping ranges**: Weight ranges cannot overlap for the same location and shipping method
@@ -48,7 +49,11 @@ Standard Shipping,US,CA,0,10,5.99,3.00
 Standard Shipping,US,CA,10,25,9.99,5.00
 Standard Shipping,CA,ON,0,10,15.99,10.00
 Standard Shipping,CA,BC,0,10,18.99,12.00
+Economy Shipping,US,,0,25,4.99,2.00
+Economy Shipping,CA,,0,25,6.99,3.00
 ```
+
+**Note**: The last two rows show country-level rates (region column is blank).
 
 ## Common Region Codes
 

--- a/app/models/rate.rb
+++ b/app/models/rate.rb
@@ -2,7 +2,6 @@ class Rate < ApplicationRecord
   belongs_to :shipping_option
 
   validates :country, presence: true, length: { is: 2 }
-  validates :region, presence: true
   validates :min_range_lbs, presence: true, numericality: { greater_than_or_equal_to: 0 }
   validates :max_range_lbs, presence: true, numericality: { greater_than: 0 }
   validates :flat_rate, presence: true, numericality: { greater_than_or_equal_to: 0 }

--- a/app/services/rate_csv_import_service.rb
+++ b/app/services/rate_csv_import_service.rb
@@ -97,9 +97,12 @@ private
     shipping_option = find_shipping_option(row[:shipping_method], row_number)
     return unless shipping_option
 
+    region_value = row[:region]&.strip
+    region_value = nil if region_value.blank?
+
     rate = shipping_option.rates.new(
       country: row[:country]&.strip&.upcase,
-      region: row[:region]&.strip,
+      region: region_value,
       min_range_lbs: row[:min_range_lbs],
       max_range_lbs: row[:max_range_lbs],
       flat_rate: row[:flat_rate],

--- a/app/services/shipping_calculation_service.rb
+++ b/app/services/shipping_calculation_service.rb
@@ -95,7 +95,16 @@ private
   end
 
   def find_best_rate(shipping_option)
-    shipping_option.rates.find { |rate| rate_matches_location?(rate) && rate_matches_weight_range?(rate) }
+    # First try to find region-specific rate
+    region_rate = shipping_option.rates.find do |rate|
+      rate_matches_location_exact?(rate) && rate_matches_weight_range?(rate)
+    end
+    return region_rate if region_rate
+
+    # Fall back to country-level rate if no region-specific rate found
+    shipping_option.rates.find do |rate|
+      rate_matches_country_only?(rate) && rate_matches_weight_range?(rate)
+    end
   end
 
   def calculate_shipping_total(shipping_option, rate)
@@ -127,8 +136,14 @@ private
 
 private
 
-  def rate_matches_location?(rate)
-    rate.country_code == ship_to_country && rate.state_code == ship_to_state
+  def rate_matches_location_exact?(rate)
+    rate.country_code == ship_to_country && 
+    rate.state_code.present? && 
+    rate.state_code == ship_to_state
+  end
+
+  def rate_matches_country_only?(rate)
+    rate.country_code == ship_to_country && rate.state_code.blank?
   end
 
   def rate_matches_weight_range?(rate)

--- a/app/services/shipping_calculation_service.rb
+++ b/app/services/shipping_calculation_service.rb
@@ -137,9 +137,9 @@ private
 private
 
   def rate_matches_location_exact?(rate)
-    rate.country_code == ship_to_country && 
-    rate.state_code.present? && 
-    rate.state_code == ship_to_state
+    rate.country_code == ship_to_country &&
+      rate.state_code.present? &&
+      rate.state_code == ship_to_state
   end
 
   def rate_matches_country_only?(rate)

--- a/app/views/rates/import.html.erb
+++ b/app/views/rates/import.html.erb
@@ -65,7 +65,7 @@
       <ul class="list-disc list-inside ml-4 space-y-1">
         <li><strong>shipping_method</strong> - Name of an existing shipping method</li>
         <li><strong>country</strong> - 2-letter country code (e.g., US, CA, MX)</li>
-        <li><strong>region</strong> - State/province code (e.g., CA, NY, ON, BC)</li>
+        <li><strong>region</strong> - <em>(Optional)</em> State/province code (e.g., CA, NY, ON, BC) - leave blank for country-level rates</li>
         <li><strong>min_range_lbs</strong> - Minimum weight in pounds (must start at 0 for each location)</li>
         <li><strong>max_range_lbs</strong> - Maximum weight in pounds</li>
         <li><strong>flat_rate</strong> - Shipping cost in dollars</li>
@@ -85,7 +85,8 @@
 Express Shipping,US,CA,0,5,9.99,5.00
 Express Shipping,US,CA,5,10,14.99,10.00
 Express Shipping,US,NY,0,5,12.99,8.00
-Standard Shipping,CA,ON,0,10,15.99,10.00</pre>
+Standard Shipping,CA,ON,0,10,15.99,10.00
+Economy Shipping,US,,0,25,4.99,2.00</pre>
     </div>
     <div class="mt-3">
       <button onclick="downloadSampleCSV()" class="text-sm text-blue-600 hover:text-blue-800 font-medium">
@@ -147,7 +148,9 @@ Standard Shipping,US,CA,0,10,5.99,3.00
 Standard Shipping,US,CA,10,25,9.99,5.00
 Standard Shipping,CA,ON,0,10,15.99,10.00
 Standard Shipping,CA,ON,10,25,22.99,15.00
-Standard Shipping,CA,BC,0,10,18.99,12.00`;
+Standard Shipping,CA,BC,0,10,18.99,12.00
+Economy Shipping,US,,0,25,4.99,2.00
+Economy Shipping,CA,,0,25,6.99,3.00`;
 
   const blob = new Blob([csvContent], { type: 'text/csv' });
   const url = window.URL.createObjectURL(blob);

--- a/test/models/rate_test.rb
+++ b/test/models/rate_test.rb
@@ -23,10 +23,9 @@ class RateTest < ActiveSupport::TestCase
     end
 
 
-    test "region should be present" do
+    test "region can be blank for country-level rates" do
       @rate.region = nil
-      assert_not @rate.valid?
-      assert_includes @rate.errors[:region], "can't be blank"
+      assert @rate.valid?
     end
 
     test "min_range_lbs should be present" do

--- a/test/services/shipping_calculation_service_country_level_test.rb
+++ b/test/services/shipping_calculation_service_country_level_test.rb
@@ -231,4 +231,3 @@ class ShippingCalculationServiceCountryLevelTest < ActiveSupport::TestCase
     assert_not service.send(:rate_matches_country_only?, region_rate)
   end
 end
-

--- a/test/services/shipping_calculation_service_country_level_test.rb
+++ b/test/services/shipping_calculation_service_country_level_test.rb
@@ -27,8 +27,11 @@ class ShippingCalculationServiceCountryLevelTest < ActiveSupport::TestCase
     result = service.call
 
     assert result[:success]
-    assert_equal 1, result[:shipping_options].length
-    assert_equal 15.99, result[:shipping_options].first[:shipping_total]
+    assert result[:shipping_options].length >= 1
+    # Find the specific shipping option we're testing
+    express_option = result[:shipping_options].find { |opt| opt[:shipping_title] == "Express Shipping" }
+    assert_not_nil express_option
+    assert_equal 15.99, express_option[:shipping_total]
   end
 
   test "should prefer region-specific rate over country-level rate" do
@@ -62,9 +65,12 @@ class ShippingCalculationServiceCountryLevelTest < ActiveSupport::TestCase
     result = service.call
 
     assert result[:success]
-    assert_equal 1, result[:shipping_options].length
+    assert result[:shipping_options].length >= 1
+    # Find the specific shipping option we're testing
+    express_option = result[:shipping_options].find { |opt| opt[:shipping_title] == "Express Shipping" }
+    assert_not_nil express_option
     # Should use the region-specific rate, not country-level
-    assert_equal 15.99, result[:shipping_options].first[:shipping_total]
+    assert_equal 15.99, express_option[:shipping_total]
   end
 
   test "should fall back to country-level rate when region-specific rate doesn't exist" do
@@ -99,9 +105,12 @@ class ShippingCalculationServiceCountryLevelTest < ActiveSupport::TestCase
     result = service.call
 
     assert result[:success]
-    assert_equal 1, result[:shipping_options].length
+    assert result[:shipping_options].length >= 1
+    # Find the specific shipping option we're testing
+    express_option = result[:shipping_options].find { |opt| opt[:shipping_title] == "Express Shipping" }
+    assert_not_nil express_option
     # Should use country-level rate since CA doesn't have region-specific rate
-    assert_equal 12.99, result[:shipping_options].first[:shipping_total]
+    assert_equal 12.99, express_option[:shipping_total]
   end
 
   test "should handle multiple weight ranges with country-level rates" do

--- a/test/services/shipping_calculation_service_country_level_test.rb
+++ b/test/services/shipping_calculation_service_country_level_test.rb
@@ -1,0 +1,234 @@
+require "test_helper"
+
+class ShippingCalculationServiceCountryLevelTest < ActiveSupport::TestCase
+  def setup
+    @company = companies(:acme)
+    @shipping_option = shipping_options(:express_shipping)
+  end
+
+  test "should match country-level rate when no region-specific rate exists" do
+    # Create only country-level rate (no region)
+    country_rate = @shipping_option.rates.create!(
+      country: "US",
+      region: nil,
+      min_range_lbs: 0,
+      max_range_lbs: 10,
+      flat_rate: 15.99,
+      min_charge: 5.00
+    )
+
+    service = ShippingCalculationService.new(
+      company: @company,
+      ship_to_country: "US",
+      ship_to_state: "CA",
+      items: []
+    )
+
+    result = service.call
+
+    assert result[:success]
+    assert_equal 1, result[:shipping_options].length
+    assert_equal 15.99, result[:shipping_options].first[:shipping_total]
+  end
+
+  test "should prefer region-specific rate over country-level rate" do
+    # Create country-level rate
+    @shipping_option.rates.create!(
+      country: "US",
+      region: nil,
+      min_range_lbs: 0,
+      max_range_lbs: 10,
+      flat_rate: 10.00,
+      min_charge: 5.00
+    )
+
+    # Create region-specific rate (should be preferred)
+    @shipping_option.rates.create!(
+      country: "US",
+      region: "CA",
+      min_range_lbs: 0,
+      max_range_lbs: 10,
+      flat_rate: 15.99,
+      min_charge: 8.00
+    )
+
+    service = ShippingCalculationService.new(
+      company: @company,
+      ship_to_country: "US",
+      ship_to_state: "CA",
+      items: []
+    )
+
+    result = service.call
+
+    assert result[:success]
+    assert_equal 1, result[:shipping_options].length
+    # Should use the region-specific rate, not country-level
+    assert_equal 15.99, result[:shipping_options].first[:shipping_total]
+  end
+
+  test "should fall back to country-level rate when region-specific rate doesn't exist" do
+    # Create region-specific rate for NY
+    @shipping_option.rates.create!(
+      country: "US",
+      region: "NY",
+      min_range_lbs: 0,
+      max_range_lbs: 10,
+      flat_rate: 20.00,
+      min_charge: 10.00
+    )
+
+    # Create country-level rate
+    @shipping_option.rates.create!(
+      country: "US",
+      region: nil,
+      min_range_lbs: 0,
+      max_range_lbs: 10,
+      flat_rate: 12.99,
+      min_charge: 7.00
+    )
+
+    # Request for CA (no CA-specific rate, should use country-level)
+    service = ShippingCalculationService.new(
+      company: @company,
+      ship_to_country: "US",
+      ship_to_state: "CA",
+      items: []
+    )
+
+    result = service.call
+
+    assert result[:success]
+    assert_equal 1, result[:shipping_options].length
+    # Should use country-level rate since CA doesn't have region-specific rate
+    assert_equal 12.99, result[:shipping_options].first[:shipping_total]
+  end
+
+  test "should handle multiple weight ranges with country-level rates" do
+    # Create country-level rates with different weight ranges
+    @shipping_option.rates.create!(
+      country: "US",
+      region: nil,
+      min_range_lbs: 0,
+      max_range_lbs: 5,
+      flat_rate: 8.99,
+      min_charge: 5.00
+    )
+
+    @shipping_option.rates.create!(
+      country: "US",
+      region: nil,
+      min_range_lbs: 5,
+      max_range_lbs: 15,
+      flat_rate: 14.99,
+      min_charge: 10.00
+    )
+
+    items = [
+      {
+        id: 1,
+        quantity: 1,
+        variant: { weight: "7", unit_of_weight: "lb" },
+      },
+    ]
+
+    service = ShippingCalculationService.new(
+      company: @company,
+      ship_to_country: "US",
+      ship_to_state: "TX",
+      items: items
+    )
+
+    result = service.call
+
+    assert result[:success]
+    # Should match the 5-15 lbs range
+    assert_equal 14.99, result[:shipping_options].first[:shipping_total]
+  end
+
+  test "should use starting_rate when neither region-specific nor country-level rate matches" do
+    # Create rate for different country
+    @shipping_option.rates.create!(
+      country: "CA",
+      region: nil,
+      min_range_lbs: 0,
+      max_range_lbs: 10,
+      flat_rate: 15.99,
+      min_charge: 10.00
+    )
+
+    service = ShippingCalculationService.new(
+      company: @company,
+      ship_to_country: "US",
+      ship_to_state: "CA",
+      items: []
+    )
+
+    result = service.call
+
+    assert result[:success]
+    # Should use shipping_option's starting_rate since no matching rate
+    assert_equal 15.99, result[:shipping_options].first[:shipping_total]
+  end
+
+  test "rate_matches_location_exact should only match when region is present and matches" do
+    country_level_rate = @shipping_option.rates.create!(
+      country: "US",
+      region: nil,
+      min_range_lbs: 0,
+      max_range_lbs: 10,
+      flat_rate: 10.00,
+      min_charge: 5.00
+    )
+
+    region_rate = @shipping_option.rates.create!(
+      country: "US",
+      region: "CA",
+      min_range_lbs: 0,
+      max_range_lbs: 10,
+      flat_rate: 15.00,
+      min_charge: 8.00
+    )
+
+    service = ShippingCalculationService.new(
+      company: @company,
+      ship_to_country: "US",
+      ship_to_state: "CA",
+      items: []
+    )
+
+    assert_not service.send(:rate_matches_location_exact?, country_level_rate)
+    assert service.send(:rate_matches_location_exact?, region_rate)
+  end
+
+  test "rate_matches_country_only should only match when region is blank" do
+    country_level_rate = @shipping_option.rates.create!(
+      country: "US",
+      region: nil,
+      min_range_lbs: 0,
+      max_range_lbs: 10,
+      flat_rate: 10.00,
+      min_charge: 5.00
+    )
+
+    region_rate = @shipping_option.rates.create!(
+      country: "US",
+      region: "CA",
+      min_range_lbs: 0,
+      max_range_lbs: 10,
+      flat_rate: 15.00,
+      min_charge: 8.00
+    )
+
+    service = ShippingCalculationService.new(
+      company: @company,
+      ship_to_country: "US",
+      ship_to_state: "CA",
+      items: []
+    )
+
+    assert service.send(:rate_matches_country_only?, country_level_rate)
+    assert_not service.send(:rate_matches_country_only?, region_rate)
+  end
+end
+

--- a/test/services/shipping_calculation_service_test.rb
+++ b/test/services/shipping_calculation_service_test.rb
@@ -353,7 +353,7 @@ class ShippingCalculationServiceTest < ActiveSupport::TestCase
     assert_not service.send(:rate_matches_weight_range?, rate)
   end
 
-  # Tests for rate_matches_location? method
+  # Tests for rate_matches_location_exact? method
   test "should match rate when country and state match" do
     rate = @shipping_option.rates.create!(
       country: "US",
@@ -371,7 +371,7 @@ class ShippingCalculationServiceTest < ActiveSupport::TestCase
       items: []
     )
 
-    assert service.send(:rate_matches_location?, rate)
+    assert service.send(:rate_matches_location_exact?, rate)
   end
 
   test "should not match rate when country does not match" do
@@ -391,7 +391,7 @@ class ShippingCalculationServiceTest < ActiveSupport::TestCase
       items: []
     )
 
-    assert_not service.send(:rate_matches_location?, rate)
+    assert_not service.send(:rate_matches_location_exact?, rate)
   end
 
   test "should not match rate when state does not match" do
@@ -411,7 +411,7 @@ class ShippingCalculationServiceTest < ActiveSupport::TestCase
       items: []
     )
 
-    assert_not service.send(:rate_matches_location?, rate)
+    assert_not service.send(:rate_matches_location_exact?, rate)
   end
 
   # Integration test for find_best_rate with weight filtering

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,11 @@ require_relative "../config/environment"
 require "rails/test_help"
 require "minitest/rails"
 
+# Build Vite assets for test environment if not already built
+unless File.exist?(Rails.root.join("public/vite-test/manifest.json"))
+  system("bin/vite build --mode test --emptyOutDir") if File.exist?("bin/vite")
+end
+
 module ActiveSupport
   class TestCase
     # Run tests in parallel with specified workers


### PR DESCRIPTION
Changes to support country-level and region-specific rates:

Model Changes:
- Remove region presence validation from Rate model
- Allow nil/blank region values for country-level rates

Service Changes (ShippingCalculationService):
- Update rate matching logic with fallback strategy
- First attempt: Match region-specific rates (exact match)
- Second attempt: Fall back to country-level rates (region is nil)
- Add rate_matches_location_exact? for region-specific matching
- Add rate_matches_country_only? for country-level matching

CSV Import Changes:
- Handle blank regions as nil in import service
- Update documentation to indicate region is optional
- Add examples of country-level rates to UI and samples

Tests:
- Add 7 comprehensive tests for country-level rate functionality
- Test region-specific rate preference over country-level
- Test fallback to country-level when no region match
- Test multiple weight ranges with country-level rates
- Update existing tests to use new method names

This allows users to:
- Set rates at country level without specifying regions
- Set region-specific rates that override country-level rates
- Mix country-level and region-specific rates as needed