### PR TITLE
Fix: Add DRI authentication to HomeController DRO-1

### DIFF
--- a/app/controllers/concerns/dri_authentication.rb
+++ b/app/controllers/concerns/dri_authentication.rb
@@ -142,7 +142,7 @@ private
     error_response = {
       error: message,
       code: code,
-      action_required: action_required
+      action_required: action_required,
     }
 
     error_response[:details] = details if details.present?
@@ -152,4 +152,3 @@ private
     render json: error_response, status: :not_found
   end
 end
-

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -4,4 +4,3 @@ class HomeController < ApplicationController
   def index
   end
 end
-

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,7 @@
 class HomeController < ApplicationController
+  include DriAuthentication
+
   def index
   end
 end
+

--- a/app/jobs/droplet_installed_job.rb
+++ b/app/jobs/droplet_installed_job.rb
@@ -17,7 +17,7 @@ class DropletInstalledJob < WebhookEventJob
     company_attributes = get_payload.fetch("company", {})
 
     company = Company.find_by(fluid_shop: company_attributes["fluid_shop"]) || Company.new
-    
+
     # Log if this is a reinstallation
     if company.persisted? && company.droplet_installation_uuid != company_attributes["droplet_installation_uuid"]
       Rails.logger.info(

--- a/app/jobs/droplet_uninstalled_job.rb
+++ b/app/jobs/droplet_uninstalled_job.rb
@@ -10,11 +10,11 @@ class DropletUninstalledJob < WebhookEventJob
         "[DropletUninstalledJob] Uninstalling droplet for #{company.fluid_shop}. " \
         "DRI: #{company.droplet_installation_uuid}"
       )
-      
+
       delete_installed_callbacks(company)
 
       company.update(uninstalled_at: Time.current)
-      
+
       Rails.logger.info(
         "[DropletUninstalledJob] Note: Users with existing sessions using DRI #{company.droplet_installation_uuid} " \
         "will receive an error message on next request and need to reinstall the droplet."

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -29,4 +29,3 @@ private
     self.installed_callback_ids ||= []
   end
 end
-

--- a/test/controllers/concerns/dri_authentication_test.rb
+++ b/test/controllers/concerns/dri_authentication_test.rb
@@ -1,162 +1,57 @@
 require "test_helper"
 
-describe DriAuthentication do
-  fixtures(:companies)
+class DriAuthenticationTest < ActionDispatch::IntegrationTest
+  fixtures :companies
 
-  # Create a minimal test controller to test the concern
-  class TestController < ApplicationController
-    include DriAuthentication
-
-    def index
-      render json: { company_id: @company.id, message: "success" }
-    end
-  end
-
-  before do
-    @controller = TestController.new
-    @request = ActionDispatch::TestRequest.create
-    @response = ActionDispatch::TestResponse.new
+  setup do
     @company = companies(:acme)
+    @valid_dri = @company.droplet_installation_uuid
   end
 
-  describe "store_dri_in_session" do
-    it "stores DRI in session when provided in params" do
-      @request.params[:dri] = @company.droplet_installation_uuid
-      @controller.stub :session, {} do
-        @controller.send(:store_dri_in_session)
-        _(@controller.session[:dri]).must_equal @company.droplet_installation_uuid
-      end
-    end
-
-    it "renders error when no DRI in params or session" do
-      @request.params[:dri] = nil
-      session_stub = {}
-
-      @controller.stub :session, session_stub do
-        @controller.stub :params, @request.params do
-          @controller.send(:store_dri_in_session)
-        end
-      end
-
-      # The method should have rendered an error
-      _(@response.status).wont_equal 200
-    end
-
-    it "uses existing session DRI when no param provided" do
-      existing_dri = @company.droplet_installation_uuid
-      @request.params[:dri] = nil
-      session_stub = { dri: existing_dri }
-
-      @controller.stub :session, session_stub do
-        @controller.stub :params, @request.params do
-          @controller.send(:store_dri_in_session)
-        end
-      end
-
-      _(session_stub[:dri]).must_equal existing_dri
-    end
+  test "accessing with valid DRI stores it in session" do
+    get root_path, params: { dri: @valid_dri }
+    assert_response :success
+    assert_equal @valid_dri, session[:dri]
   end
 
-  describe "find_company_by_dri" do
-    it "finds company when valid DRI is in session" do
-      session_stub = { dri: @company.droplet_installation_uuid }
-
-      @controller.stub :session, session_stub do
-        @controller.stub :render, nil do
-          @controller.send(:find_company_by_dri)
-        end
-      end
-
-      _(@controller.instance_variable_get(:@company)).must_equal @company
-    end
-
-    it "handles missing company with proper error response" do
-      invalid_dri = "dri_invalid123"
-      session_stub = { dri: invalid_dri }
-      rendered = false
-
-      @controller.stub :session, session_stub do
-        @controller.stub :render, ->(*args) { rendered = true; args } do
-          @controller.send(:find_company_by_dri)
-        end
-      end
-
-      _(rendered).must_equal true
-    end
-
-    it "handles uninstalled company with proper error response" do
-      @company.update(uninstalled_at: Time.current)
-      session_stub = { dri: @company.droplet_installation_uuid }
-      rendered = false
-
-      @controller.stub :session, session_stub do
-        @controller.stub :render, ->(*args) { rendered = true; args } do
-          @controller.send(:find_company_by_dri)
-        end
-      end
-
-      _(rendered).must_equal true
-    end
-
-    it "handles inactive company with proper error response" do
-      @company.update(active: false, uninstalled_at: nil)
-      session_stub = { dri: @company.droplet_installation_uuid }
-      rendered = false
-
-      @controller.stub :session, session_stub do
-        @controller.stub :render, ->(*args) { rendered = true; args } do
-          @controller.send(:find_company_by_dri)
-        end
-      end
-
-      _(rendered).must_equal true
-    end
+  test "accessing with invalid DRI returns error" do
+    get shipping_options_path, params: { dri: "dri_invalid123" }
+    assert_response :not_found
+    json_response = JSON.parse(response.body)
+    assert_equal "DRI_NOT_FOUND", json_response["code"]
+    assert_equal "reinstall", json_response["action_required"]
   end
 
-  describe "render_dri_error" do
-    it "renders JSON error with all provided fields" do
-      rendered_json = nil
-      rendered_status = nil
+  test "accessing with uninstalled company DRI returns error" do
+    @company.update(uninstalled_at: Time.current)
+    get shipping_options_path, params: { dri: @valid_dri }
+    assert_response :not_found
+    json_response = JSON.parse(response.body)
+    assert_equal "DROPLET_UNINSTALLED", json_response["code"]
+  end
 
-      @controller.stub :render, ->(json:, status:) {
-        rendered_json = json
-        rendered_status = status
-      } do
-        @controller.send(:render_dri_error,
-          message: "Test error",
-          code: "TEST_ERROR",
-          action_required: "test_action",
-          details: "Test details",
-          dri: "dri_test123"
-        )
-      end
+  test "accessing with inactive company DRI returns error" do
+    @company.update(active: false, uninstalled_at: nil)
+    get shipping_options_path, params: { dri: @valid_dri }
+    assert_response :not_found
+    json_response = JSON.parse(response.body)
+    assert_equal "DROPLET_INACTIVE", json_response["code"]
+  end
 
-      _(rendered_json[:error]).must_equal "Test error"
-      _(rendered_json[:code]).must_equal "TEST_ERROR"
-      _(rendered_json[:action_required]).must_equal "test_action"
-      _(rendered_json[:details]).must_equal "Test details"
-      _(rendered_json[:dri]).must_equal "dri_test123"
-      _(rendered_status).must_equal :not_found
-    end
+  test "accessing without DRI when session has valid DRI works" do
+    # First request with DRI to set session
+    get root_path, params: { dri: @valid_dri }
+    assert_response :success
 
-    it "renders JSON error without optional fields" do
-      rendered_json = nil
+    # Second request without DRI should use session
+    get shipping_options_path
+    assert_response :success
+  end
 
-      @controller.stub :render, ->(json:, status:) {
-        rendered_json = json
-      } do
-        @controller.send(:render_dri_error,
-          message: "Test error",
-          code: "TEST_ERROR",
-          action_required: "test_action"
-        )
-      end
-
-      _(rendered_json[:error]).must_equal "Test error"
-      _(rendered_json[:code]).must_equal "TEST_ERROR"
-      _(rendered_json[:action_required]).must_equal "test_action"
-      _(rendered_json.key?(:details)).must_equal false
-      _(rendered_json.key?(:dri)).must_equal false
-    end
+  test "accessing without DRI and no session returns error" do
+    get shipping_options_path
+    assert_response :not_found
+    json_response = JSON.parse(response.body)
+    assert_equal "DRI_REQUIRED", json_response["code"]
   end
 end

--- a/test/controllers/concerns/dri_authentication_test.rb
+++ b/test/controllers/concerns/dri_authentication_test.rb
@@ -31,13 +31,13 @@ describe DriAuthentication do
     it "renders error when no DRI in params or session" do
       @request.params[:dri] = nil
       session_stub = {}
-      
+
       @controller.stub :session, session_stub do
         @controller.stub :params, @request.params do
           @controller.send(:store_dri_in_session)
         end
       end
-      
+
       # The method should have rendered an error
       _(@response.status).wont_equal 200
     end
@@ -46,13 +46,13 @@ describe DriAuthentication do
       existing_dri = @company.droplet_installation_uuid
       @request.params[:dri] = nil
       session_stub = { dri: existing_dri }
-      
+
       @controller.stub :session, session_stub do
         @controller.stub :params, @request.params do
           @controller.send(:store_dri_in_session)
         end
       end
-      
+
       _(session_stub[:dri]).must_equal existing_dri
     end
   end
@@ -60,13 +60,13 @@ describe DriAuthentication do
   describe "find_company_by_dri" do
     it "finds company when valid DRI is in session" do
       session_stub = { dri: @company.droplet_installation_uuid }
-      
+
       @controller.stub :session, session_stub do
         @controller.stub :render, nil do
           @controller.send(:find_company_by_dri)
         end
       end
-      
+
       _(@controller.instance_variable_get(:@company)).must_equal @company
     end
 
@@ -74,13 +74,13 @@ describe DriAuthentication do
       invalid_dri = "dri_invalid123"
       session_stub = { dri: invalid_dri }
       rendered = false
-      
+
       @controller.stub :session, session_stub do
         @controller.stub :render, ->(*args) { rendered = true; args } do
           @controller.send(:find_company_by_dri)
         end
       end
-      
+
       _(rendered).must_equal true
     end
 
@@ -88,13 +88,13 @@ describe DriAuthentication do
       @company.update(uninstalled_at: Time.current)
       session_stub = { dri: @company.droplet_installation_uuid }
       rendered = false
-      
+
       @controller.stub :session, session_stub do
         @controller.stub :render, ->(*args) { rendered = true; args } do
           @controller.send(:find_company_by_dri)
         end
       end
-      
+
       _(rendered).must_equal true
     end
 
@@ -102,13 +102,13 @@ describe DriAuthentication do
       @company.update(active: false, uninstalled_at: nil)
       session_stub = { dri: @company.droplet_installation_uuid }
       rendered = false
-      
+
       @controller.stub :session, session_stub do
         @controller.stub :render, ->(*args) { rendered = true; args } do
           @controller.send(:find_company_by_dri)
         end
       end
-      
+
       _(rendered).must_equal true
     end
   end
@@ -117,8 +117,8 @@ describe DriAuthentication do
     it "renders JSON error with all provided fields" do
       rendered_json = nil
       rendered_status = nil
-      
-      @controller.stub :render, ->(json:, status:) { 
+
+      @controller.stub :render, ->(json:, status:) {
         rendered_json = json
         rendered_status = status
       } do
@@ -130,7 +130,7 @@ describe DriAuthentication do
           dri: "dri_test123"
         )
       end
-      
+
       _(rendered_json[:error]).must_equal "Test error"
       _(rendered_json[:code]).must_equal "TEST_ERROR"
       _(rendered_json[:action_required]).must_equal "test_action"
@@ -141,8 +141,8 @@ describe DriAuthentication do
 
     it "renders JSON error without optional fields" do
       rendered_json = nil
-      
-      @controller.stub :render, ->(json:, status:) { 
+
+      @controller.stub :render, ->(json:, status:) {
         rendered_json = json
       } do
         @controller.send(:render_dri_error,
@@ -151,7 +151,7 @@ describe DriAuthentication do
           action_required: "test_action"
         )
       end
-      
+
       _(rendered_json[:error]).must_equal "Test error"
       _(rendered_json[:code]).must_equal "TEST_ERROR"
       _(rendered_json[:action_required]).must_equal "test_action"
@@ -160,4 +160,3 @@ describe DriAuthentication do
     end
   end
 end
-

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -1,8 +1,11 @@
 require "test_helper"
 
 describe HomeController do
+  fixtures :companies
+
   it "gets index" do
-    get root_url
+    company = companies(:acme)
+    get root_url, params: { dri: company.droplet_installation_uuid }
     must_respond_with :success
   end
 end

--- a/test/jobs/droplet_installed_job_test.rb
+++ b/test/jobs/droplet_installed_job_test.rb
@@ -188,8 +188,8 @@ describe DropletInstalledJob do
           "droplet_uuid" => company.company_droplet_uuid,
           "authentication_token" => company.authentication_token,
           "webhook_verification_token" => company.webhook_verification_token,
-          "droplet_installation_uuid" => "dri_new_installation_uuid"
-        }
+          "droplet_installation_uuid" => "dri_new_installation_uuid",
+        },
       }
 
       job = DropletInstalledJob.new
@@ -215,8 +215,8 @@ describe DropletInstalledJob do
           "droplet_uuid" => company.company_droplet_uuid,
           "authentication_token" => company.authentication_token,
           "webhook_verification_token" => company.webhook_verification_token,
-          "droplet_installation_uuid" => new_dri
-        }
+          "droplet_installation_uuid" => new_dri,
+        },
       }
 
       job = DropletInstalledJob.new
@@ -241,8 +241,8 @@ describe DropletInstalledJob do
           "droplet_uuid" => company.company_droplet_uuid,
           "authentication_token" => company.authentication_token,
           "webhook_verification_token" => company.webhook_verification_token,
-          "droplet_installation_uuid" => new_dri
-        }
+          "droplet_installation_uuid" => new_dri,
+        },
       }
 
       log_output = StringIO.new
@@ -261,4 +261,3 @@ describe DropletInstalledJob do
     end
   end
 end
-

--- a/test/models/company_test.rb
+++ b/test/models/company_test.rb
@@ -119,4 +119,3 @@ describe Company do
     end
   end
 end
-


### PR DESCRIPTION
HomeController was missing the DriAuthentication concern, which meant that when users accessed the root path (/) with a new DRI parameter, the session wasn't being updated. This caused the stale DRI to persist even when Fluid was correctly providing the new DRI in the iframe URL.

Now all user-facing controllers (Home, ShippingOptions, Rates) include the DriAuthentication concern and will properly update the session when a DRI parameter is provided.