### PR TITLE
Fix callback definition name to update_cart_shipping

### DIFF
--- a/app/services/droplet_installation_service.rb
+++ b/app/services/droplet_installation_service.rb
@@ -59,10 +59,10 @@ private
 
     client = FluidClient.new
 
-    # Always register the shipping options callback - required for droplet functionality
+    # Always register the shipping callback - required for droplet functionality
     base_url = ENV.fetch("DROPLET_URL", "https://fluid-droplet-shipping-options-106074092699.europe-west1.run.app")
     callback = {
-      definition_name: "shipping_options",
+      definition_name: "update_cart_shipping",
       url: "#{base_url}/callbacks/shipping_options",
       timeout_in_seconds: 10,
       active: true,


### PR DESCRIPTION
The correct Fluid callback definition name is 'update_cart_shipping', not 'shipping_options'. This was causing callback registration to fail with 'is not a valid definition name' error.

Verified from Fluid API /api/callback/definitions endpoint.