### PR TITLE
Fix callback cleanup on uninstall and use correct callback name DRO-1

### DIFF
--- a/app/services/droplet_installation_service.rb
+++ b/app/services/droplet_installation_service.rb
@@ -86,11 +86,11 @@ private
       )
     end
   rescue => e
-    # Log error but don't fail the installation
+    # Log error and fail the installation so we know something went wrong
     Rails.logger.error(
       "[DropletInstallationService] Failed to register callback: #{e.message}"
     )
     Rails.logger.error(e.backtrace.join("\n"))
-    raise e  # Re-raise so installation fails if callback fails
+    raise e
   end
 end

--- a/app/services/droplet_uninstallation_service.rb
+++ b/app/services/droplet_uninstallation_service.rb
@@ -51,21 +51,40 @@ private
   end
 
   def delete_installed_callbacks(company)
-    return unless company.installed_callback_ids.present?
     # Skip callback deletion in test environment
     return if Rails.env.test?
 
     client = FluidClient.new
+    deleted_count = 0
 
-    company.installed_callback_ids.each do |callback_id|
-      begin
-        client.callback_registrations.delete(callback_id)
-        Rails.logger.info("[DropletUninstallationService] Deleted callback: #{callback_id}")
-      rescue => e
-        Rails.logger.error(
-          "[DropletUninstallationService] Failed to delete callback #{callback_id}: #{e.message}"
-        )
+    # Get all callback registrations and delete our shipping callback
+    begin
+      response = client.callback_registrations.get
+      registrations = response&.dig("callback_registrations") || []
+
+      registrations.each do |registration|
+        # Delete any callback with our definition name
+        if registration["definition_name"] == "update_cart_shipping"
+          callback_id = registration["uuid"]
+          begin
+            client.callback_registrations.delete(callback_id)
+            deleted_count += 1
+            Rails.logger.info("[DropletUninstallationService] Deleted callback: #{callback_id}")
+          rescue => e
+            Rails.logger.error(
+              "[DropletUninstallationService] Failed to delete callback #{callback_id}: #{e.message}"
+            )
+          end
+        end
       end
+
+      Rails.logger.info(
+        "[DropletUninstallationService] Deleted #{deleted_count} callback(s)"
+      )
+    rescue => e
+      Rails.logger.error(
+        "[DropletUninstallationService] Failed to list callbacks for deletion: #{e.message}"
+      )
     end
 
     company.update(installed_callback_ids: [])


### PR DESCRIPTION
Installation changes:
- Use correct Fluid callback name: 'update_cart_shipping'
- Store callback UUID for future cleanup
- Fail installation if callback registration fails

Uninstallation changes:
- List all callback registrations (don't rely on stored IDs)
- Delete any callbacks with definition_name 'update_cart_shipping'
- Works even if callback IDs weren't stored during install

This ensures clean reinstalls - callbacks are properly deleted on uninstall, so reinstall won't get 'already registered' errors.