### PR TITLE
Fix tab navigation highlighting and landing page redirect STU-1067

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,5 +2,10 @@ class HomeController < ApplicationController
   include DriAuthentication
 
   def index
+    # If we have a valid company/DRI session, redirect to shipping options
+    if @company.present?
+      redirect_to shipping_options_path
+    end
+    # Otherwise, show the landing page with the Fluid logo
   end
 end

--- a/app/views/shared/_shipping_options_navigation.html.erb
+++ b/app/views/shared/_shipping_options_navigation.html.erb
@@ -87,20 +87,39 @@ function initializeNavigation() {
     if (shippingContent) {
       const contentText = shippingContent.textContent || shippingContent.innerText;
       
-      // More specific detection based on actual content - check Overview first
+      // More specific detection based on actual content
+      // Check for more specific markers first to avoid false matches
+      
+      // Check for Overview - most specific patterns first
       if (contentText.includes('Shipping Overview') || contentText.includes('Monitor your shipping') || contentText.includes('Active Methods') || contentText.includes('Configured Regions')) {
         return 'overview';
-      } else if (contentText.includes('Rate Tables') || contentText.includes('rate table') || contentText.includes('Add Rate Table')) {
-        return 'rate_tables';
-      } else if (contentText.includes('Shipping Methods') || contentText.includes('shipping method') || contentText.includes('Add Method') || contentText.includes('Express shipping') || contentText.includes('Normal Shipping')) {
+      }
+      
+      // Check for Shipping Methods - look for page title and specific content
+      // Use more specific patterns to avoid false matches with rate tables mentions
+      if (contentText.includes('Manage and configure your shipping methods') || 
+          (contentText.includes('Shipping Methods') && !contentText.includes('Rate Tables Overview'))) {
         return 'shipping_methods';
+      }
+      
+      // Check for Rate Tables last - this is the least specific
+      if (contentText.includes('Rate Tables Overview') || contentText.includes('Add Rate Table') || 
+          (contentText.includes('Rate Tables') && !contentText.includes('Shipping Methods'))) {
+        return 'rate_tables';
       }
     }
     
     // Fallback to URL-based detection
     if (currentPath.includes('/rates') || currentPath.includes('/rate_tables')) {
       return 'rate_tables';
+    } else if (currentPath.includes('/shipping_methods')) {
+      return 'shipping_methods';
     } else if (currentPath.includes('/shipping_options')) {
+      // If path is exactly /shipping_options, it's the overview
+      if (currentPath === '/shipping_options' || currentPath === '/shipping_options/') {
+        return 'overview';
+      }
+      // Otherwise could be shipping methods or other
       return 'shipping_methods';
     } else {
       return 'overview';

--- a/test/controllers/concerns/dri_authentication_test.rb
+++ b/test/controllers/concerns/dri_authentication_test.rb
@@ -10,7 +10,8 @@ class DriAuthenticationTest < ActionDispatch::IntegrationTest
 
   test "accessing with valid DRI stores it in session" do
     get root_path, params: { dri: @valid_dri }
-    assert_response :success
+    assert_response :redirect
+    assert_redirected_to shipping_options_path
     assert_equal @valid_dri, session[:dri]
   end
 
@@ -41,7 +42,8 @@ class DriAuthenticationTest < ActionDispatch::IntegrationTest
   test "accessing without DRI when session has valid DRI works" do
     # First request with DRI to set session
     get root_path, params: { dri: @valid_dri }
-    assert_response :success
+    assert_response :redirect
+    assert_redirected_to shipping_options_path
 
     # Second request without DRI should use session
     get shipping_options_path

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -3,9 +3,10 @@ require "test_helper"
 describe HomeController do
   fixtures :companies
 
-  it "gets index" do
+  it "redirects to shipping options when valid DRI session exists" do
     company = companies(:acme)
     get root_url, params: { dri: company.droplet_installation_uuid }
-    must_respond_with :success
+    must_respond_with :redirect
+    must_redirect_to shipping_options_path
   end
 end


### PR DESCRIPTION
- Fixed incorrect tab highlighting when clicking Shipping Methods
  * Tab detection now uses more specific content patterns
  * Checks for unique subtitle 'Manage and configure your shipping methods'
  * Prevents false matches with rate tables mentions

- Fixed landing page appearing instead of overview
  * HomeController now redirects to shipping_options_path when valid DRI session exists
  * Landing page with Fluid logo only shows when no valid session