### PR TITLE
Fix CSV upload internal server error by wrapping rate views in turbo … STU-1067

### DIFF
--- a/app/views/rates/_rate_tables.html.erb
+++ b/app/views/rates/_rate_tables.html.erb
@@ -59,7 +59,7 @@
                       </div>
                       <div>
                         <div class="text-sm font-medium text-gray-900"><%= shipping_option.name %></div>
-                        <div class="text-sm text-gray-500"><%= shipping_option.countries.join(', ') %></div>
+                        <div class="text-sm text-gray-500"><%= shipping_option.countries&.join(', ') || '-' %></div>
                       </div>
                     </div>
                   </td>

--- a/app/views/rates/edit.html.erb
+++ b/app/views/rates/edit.html.erb
@@ -1,10 +1,11 @@
 <% content_for :title, "Edit Rate Table" %>
 
-<div class="bg-white rounded-2xl shadow-sm border border-gray-100 p-8">
-  <div class="mb-8">
-    <h1 class="text-2xl font-bold text-gray-900 mb-2">Edit Rate Table</h1>
-    <p class="text-gray-600">Update pricing for a specific shipping method and region.</p>
-  </div>
+<%= turbo_frame_tag "shipping_content" do %>
+  <div class="bg-white rounded-2xl shadow-sm border border-gray-100 p-8">
+    <div class="mb-8">
+      <h1 class="text-2xl font-bold text-gray-900 mb-2">Edit Rate Table</h1>
+      <p class="text-gray-600">Update pricing for a specific shipping method and region.</p>
+    </div>
 
   <%= form_with model: [@rate], url: rate_table_path(@rate), method: :patch, local: true, class: "space-y-6" do |form| %>
     <% if @rate.errors.any? %>
@@ -306,3 +307,5 @@ document.addEventListener('turbo:render', function() {
 });
 
 </script>
+  </div>
+<% end %>

--- a/app/views/rates/import.html.erb
+++ b/app/views/rates/import.html.erb
@@ -1,8 +1,9 @@
-<div class="bg-white rounded-2xl shadow-sm border border-gray-100 p-8 max-w-4xl mx-auto">
-  <div class="mb-8">
-    <h1 class="text-2xl font-bold text-gray-900 mb-2">Import Rate Tables from CSV</h1>
-    <p class="text-gray-600">Upload a CSV file to bulk import shipping rates for your methods.</p>
-  </div>
+<%= turbo_frame_tag "shipping_content" do %>
+  <div class="bg-white rounded-2xl shadow-sm border border-gray-100 p-8 max-w-4xl mx-auto">
+    <div class="mb-8">
+      <h1 class="text-2xl font-bold text-gray-900 mb-2">Import Rate Tables from CSV</h1>
+      <p class="text-gray-600">Upload a CSV file to bulk import shipping rates for your methods.</p>
+    </div>
 
   <% if flash[:alert] || flash[:errors] || flash[:row_errors] %>
     <div class="bg-red-50 border border-red-200 rounded-xl p-4 mb-6">
@@ -163,4 +164,6 @@ Economy Shipping,CA,,0,25,6.99,3.00`;
   document.body.removeChild(a);
 }
 </script>
+  </div>
+<% end %>
 

--- a/app/views/rates/new.html.erb
+++ b/app/views/rates/new.html.erb
@@ -1,8 +1,9 @@
-<div class="bg-white rounded-2xl shadow-sm border border-gray-100 p-8">
-  <div class="mb-8">
-    <h1 class="text-2xl font-bold text-gray-900 mb-2">Create New Rate Table</h1>
-    <p class="text-gray-600">Configure pricing for a specific shipping method and region.</p>
-  </div>
+<%= turbo_frame_tag "shipping_content" do %>
+  <div class="bg-white rounded-2xl shadow-sm border border-gray-100 p-8">
+    <div class="mb-8">
+      <h1 class="text-2xl font-bold text-gray-900 mb-2">Create New Rate Table</h1>
+      <p class="text-gray-600">Configure pricing for a specific shipping method and region.</p>
+    </div>
 
   <%= form_with model: @rate, url: rate_tables_path, local: true, class: "space-y-6" do |form| %>
     <% if @rate.errors.any? %>
@@ -280,3 +281,5 @@ document.addEventListener('turbo:render', function() {
 });
 
 </script>
+  </div>
+<% end %>


### PR DESCRIPTION
…frames

- Wrap import, new, and edit rate views in turbo_frame_tag 'shipping_content'
- This fixes the Turbo Frame mismatch that caused internal server errors when CSV upload completed and redirected to the rates index page
- Add safe navigation operator for countries field to prevent nil errors
- All rate views now consistently use the same turbo frame for seamless navigation