### PR TITLE
Add pagination and filtering to Rate table page STU-1067

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem "solid_queue"
 gem "thruster", require: false
 gem "turbo-rails"
 gem "vite_rails", "~> 3.0", ">= 3.0.19"
+gem "pagy", "~> 9.4"
 
 group :development, :test do
   gem "brakeman", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,6 +223,7 @@ GEM
       racc (~> 1.4)
     orm_adapter (0.5.0)
     ostruct (0.6.2)
+    pagy (9.4.0)
     parallel (1.27.0)
     parser (3.3.8.0)
       ast (~> 2.4.1)
@@ -440,6 +441,7 @@ DEPENDENCIES
   json_schemer (~> 2.4)
   kamal
   minitest-rails (~> 8.0.0)
+  pagy (~> 9.4)
   pg (~> 1.1)
   propshaft
   pry-nav (~> 1.0.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  include Pagy::Backend
+
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
 

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -64,3 +64,29 @@ a:not([class*="text-"]) {
 .error-field {
   @apply text-red-500;
 }
+
+/* Pagy pagination styles */
+.pagy-nav {
+  @apply flex items-center gap-1;
+}
+
+.pagy-nav a,
+.pagy-nav .page {
+  @apply inline-flex items-center justify-center px-3 py-2 text-sm font-medium rounded-lg transition-all duration-200;
+}
+
+.pagy-nav a {
+  @apply text-gray-700 bg-white border border-gray-300 hover:bg-blue-50 hover:border-blue-400 hover:text-blue-700;
+}
+
+.pagy-nav .current {
+  @apply bg-blue-600 text-white border border-blue-600 cursor-default;
+}
+
+.pagy-nav .disabled {
+  @apply text-gray-400 bg-gray-100 border border-gray-200 cursor-not-allowed;
+}
+
+.pagy-nav .gap {
+  @apply text-gray-500 px-3 py-2;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,6 @@
 module ApplicationHelper
+  include Pagy::Frontend
+
   def format_settings_values(values)
     return "" if values.blank?
 

--- a/app/views/rates/_rate_tables.html.erb
+++ b/app/views/rates/_rate_tables.html.erb
@@ -154,7 +154,7 @@
             Showing <span class="font-medium"><%= @pagy.from %></span> to <span class="font-medium"><%= @pagy.to %></span> of <span class="font-medium"><%= @pagy.count %></span> results
           </div>
           <div class="pagy-nav">
-            <%== pagy_nav(@pagy, aria_label: 'Rate tables pagination', params: { shipping_method: params[:shipping_method], country: params[:country], region: params[:region], weight_min: params[:weight_min], weight_max: params[:weight_max] }.compact) %>
+            <%== pagy_nav(@pagy, aria_label: 'Rate tables pagination') %>
           </div>
         </div>
       <% else %>

--- a/app/views/rates/_rate_tables.html.erb
+++ b/app/views/rates/_rate_tables.html.erb
@@ -34,8 +34,60 @@
   <% end %>
 
   <% unless @shipping_option %>
+    <!-- Filters Section -->
+    <div class="mb-6 bg-gray-50 rounded-xl p-6 border border-gray-200">
+      <%= form_with url: rate_tables_path, method: :get, local: true, class: "space-y-4" do |f| %>
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
+          <!-- Shipping Method Filter -->
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-2">Shipping Method</label>
+            <%= select_tag :shipping_method,
+                options_for_select([["All Methods", ""]] + @shipping_options.map { |so| [so.name, so.id] }, params[:shipping_method]),
+                class: "w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200" %>
+          </div>
+
+          <!-- Country Filter -->
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-2">Country</label>
+            <%= select_tag :country,
+                options_for_select([["All Countries", ""]] + @countries.map { |c| [c, c] }, params[:country]),
+                class: "w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200" %>
+          </div>
+
+          <!-- Region Filter -->
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-2">Region</label>
+            <%= select_tag :region,
+                options_for_select([["All Regions", ""]] + @regions.map { |r| [r, r] }, params[:region]),
+                class: "w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200" %>
+          </div>
+
+          <!-- Min Weight Filter -->
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-2">Min Weight (lbs)</label>
+            <%= number_field_tag :weight_min, params[:weight_min],
+                placeholder: "Min weight",
+                class: "w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200" %>
+          </div>
+
+          <!-- Max Weight Filter -->
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-2">Max Weight (lbs)</label>
+            <%= number_field_tag :weight_max, params[:weight_max],
+                placeholder: "Max weight",
+                class: "w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all duration-200" %>
+          </div>
+        </div>
+
+        <div class="flex gap-3">
+          <%= f.submit "Apply Filters", class: "inline-flex items-center px-6 py-3 bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-700 hover:to-blue-800 text-white font-medium rounded-xl shadow-lg hover:shadow-xl transition-all duration-200 transform hover:scale-105" %>
+          <%= link_to "Clear Filters", rate_tables_path, class: "inline-flex items-center px-6 py-3 bg-gray-100 hover:bg-gray-200 text-gray-700 font-medium rounded-xl transition-all duration-200" %>
+        </div>
+      <% end %>
+    </div>
+
     <div class="overflow-x-auto">
-      <% if @shipping_options.any? && @shipping_options.joins(:rates).any? %>
+      <% if @rates&.any? %>
         <table class="min-w-full divide-y divide-gray-200">
           <thead class="bg-gray-50">
             <tr>
@@ -49,54 +101,62 @@
             </tr>
           </thead>
           <tbody class="bg-white divide-y divide-gray-200">
-            <% @shipping_options.includes(:rates).each do |shipping_option| %>
-              <% shipping_option.rates.each do |rate| %>
-                <tr class="hover:bg-gray-50">
-                  <td class="px-6 py-4 whitespace-nowrap">
-                    <div class="flex items-center">
-                      <div class="w-8 h-8 bg-blue-500 rounded-lg flex items-center justify-center mr-3">
-                        <i class="fa-solid fa-truck text-white text-sm"></i>
-                      </div>
-                      <div>
-                        <div class="text-sm font-medium text-gray-900"><%= shipping_option.name %></div>
-                        <div class="text-sm text-gray-500"><%= shipping_option.countries&.join(', ') || '-' %></div>
-                      </div>
+            <% @rates.each do |rate| %>
+              <tr class="hover:bg-gray-50">
+                <td class="px-6 py-4 whitespace-nowrap">
+                  <div class="flex items-center">
+                    <div class="w-8 h-8 bg-blue-500 rounded-lg flex items-center justify-center mr-3">
+                      <i class="fa-solid fa-truck text-white text-sm"></i>
                     </div>
-                  </td>
-                  <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                    <%= rate.country %>
-                  </td>
-                  <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                    <%= rate.region.present? ? rate.region : "-" %>
-                  </td>
-                  <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                    <%= rate.weight_range %>
-                  </td>
-                  <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-blue-600">
-                    $<%= number_with_precision(rate.flat_rate, precision: 2) %>
-                  </td>
-                  <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-green-600">
-                    $<%= number_with_precision(rate.min_charge, precision: 2) %>
-                  </td>
-                  <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
-                    <%= link_to edit_rate_table_path(rate), class: "text-blue-600 hover:text-blue-900 mr-3", data: { turbo_frame: "_top" } do %>
-                      Edit
-                    <% end %>
-                    <button class="delete-rate-btn text-red-600 hover:text-red-900" 
-                            style: "color: #dc2626 !important;"
-                            data-rate-id="<%= rate.id %>"
-                            data-rate-country="<%= rate.country %>"
-                            data-rate-region="<%= rate.region %>"
-                            data-shipping-option-name="<%= rate.shipping_option.name %>"
-                            data-delete-url="<%= rate_table_path(rate) %>">
-                      Delete
-                    </button>
-                  </td>
-                </tr>
-              <% end %>
+                    <div>
+                      <div class="text-sm font-medium text-gray-900"><%= rate.shipping_option.name %></div>
+                      <div class="text-sm text-gray-500"><%= rate.shipping_option.countries&.join(', ') || '-' %></div>
+                    </div>
+                  </div>
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                  <%= rate.country %>
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                  <%= rate.region.present? ? rate.region : "-" %>
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                  <%= rate.weight_range %>
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-blue-600">
+                  $<%= number_with_precision(rate.flat_rate, precision: 2) %>
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-green-600">
+                  $<%= number_with_precision(rate.min_charge, precision: 2) %>
+                </td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
+                  <%= link_to edit_rate_table_path(rate), class: "text-blue-600 hover:text-blue-900 mr-3", data: { turbo_frame: "_top" } do %>
+                    Edit
+                  <% end %>
+                  <button class="delete-rate-btn text-red-600 hover:text-red-900"
+                          style: "color: #dc2626 !important;"
+                          data-rate-id="<%= rate.id %>"
+                          data-rate-country="<%= rate.country %>"
+                          data-rate-region="<%= rate.region %>"
+                          data-shipping-option-name="<%= rate.shipping_option.name %>"
+                          data-delete-url="<%= rate_table_path(rate) %>">
+                    Delete
+                  </button>
+                </td>
+              </tr>
             <% end %>
           </tbody>
         </table>
+
+        <!-- Pagination -->
+        <div class="mt-6 flex flex-col sm:flex-row items-center justify-between border-t border-gray-200 pt-6 gap-4">
+          <div class="text-sm text-gray-700">
+            Showing <span class="font-medium"><%= @pagy.from %></span> to <span class="font-medium"><%= @pagy.to %></span> of <span class="font-medium"><%= @pagy.count %></span> results
+          </div>
+          <div class="pagy-nav">
+            <%== pagy_nav(@pagy, aria_label: 'Rate tables pagination', params: { shipping_method: params[:shipping_method], country: params[:country], region: params[:region], weight_min: params[:weight_min], weight_max: params[:weight_max] }.compact) %>
+          </div>
+        </div>
       <% else %>
         <div class="text-center py-12">
           <div class="mx-auto h-12 w-12 text-gray-400">

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Pagy initializer file (9.4.0)
+# Customize only what you really need and notice that the arrays/hashes are frozen.
+
+# Default page size
+Pagy::DEFAULT[:limit] = 20
+
+# Better user experience handled automatically
+require "pagy/extras/overflow"
+Pagy::DEFAULT[:overflow] = :last_page
+
+# Enable i18n
+require "pagy/extras/i18n"


### PR DESCRIPTION
- Added pagy gem for pagination support
- Implemented filtering by shipping method, country, region, and weight range
- Updated rates controller to handle pagination and filter parameters
- Added filter UI with dropdowns and input fields
- Added pagination UI with styled navigation
- Shows 20 results per page with page navigation
- Preserves filter parameters when navigating between pages
- Added custom Tailwind CSS styles for pagination