### PR TITLE
Increase weight range precision to 4 decimal places STU-1067

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,13 @@ jobs:
       - name: Run JavaScript tests
         run: yarn test
 
+      - name: Setup database
+        env:
+          RAILS_ENV: test
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432
+          REDIS_URL: redis://localhost:6379/0
+        run: bin/rails db:create db:migrate
+
       - name: Run Rails tests
         env:
           RAILS_ENV: test

--- a/CSV_IMPORT_GUIDE.md
+++ b/CSV_IMPORT_GUIDE.md
@@ -22,8 +22,8 @@ Your CSV file **must** include these columns (order doesn't matter):
 | `shipping_method` | String | Name of existing shipping method | Express Shipping |
 | `country` | String (2 chars) | ISO 2-letter country code | US, CA, MX |
 | `region` | String (optional) | State/province **code** (leave blank for country-level rates) | CA, NY, ON, BC or blank |
-| `min_range_lbs` | Decimal | Minimum weight in pounds | 0, 5.5, 10 |
-| `max_range_lbs` | Decimal | Maximum weight in pounds | 5, 10.5, 25 |
+| `min_range_lbs` | Decimal (4 decimals) | Minimum weight in pounds | 0, 5.5, 10.1234 |
+| `max_range_lbs` | Decimal (4 decimals) | Maximum weight in pounds | 5, 10.5, 25.9999 |
 | `flat_rate` | Decimal | Shipping cost in dollars | 9.99, 15.50 |
 | `min_charge` | Decimal | Minimum charge in dollars | 5.00, 10.00 |
 

--- a/app/views/rates/edit.html.erb
+++ b/app/views/rates/edit.html.erb
@@ -59,18 +59,18 @@
         <%= form.label :min_range_lbs, "Minimum Weight (lbs)", class: "block text-sm font-medium text-gray-700 mb-2" %>
         <%= form.number_field :min_range_lbs, 
             class: "w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent",
-            step: 0.1,
+            step: 0.0001,
             min: 0,
-            placeholder: "e.g., 10.0" %>
+            placeholder: "e.g., 10.0000" %>
       </div>
 
       <div>
         <%= form.label :max_range_lbs, "Maximum Weight (lbs)", class: "block text-sm font-medium text-gray-700 mb-2" %>
         <%= form.number_field :max_range_lbs, 
             class: "w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent",
-            step: 0.1,
+            step: 0.0001,
             min: 0,
-            placeholder: "e.g., 12.0" %>
+            placeholder: "e.g., 12.0000" %>
       </div>
 
       <div>

--- a/app/views/rates/new.html.erb
+++ b/app/views/rates/new.html.erb
@@ -57,14 +57,14 @@
         <%= form.label :min_range_lbs, "Minimum Weight (lbs)", class: "block text-sm font-medium text-gray-700 mb-2" %>
         <%= form.number_field :min_range_lbs, 
             class: "w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent",
-            step: 0.01, min: 0, placeholder: "0.00" %>
+            step: 0.0001, min: 0, placeholder: "0.0000" %>
       </div>
 
       <div>
         <%= form.label :max_range_lbs, "Maximum Weight (lbs)", class: "block text-sm font-medium text-gray-700 mb-2" %>
         <%= form.number_field :max_range_lbs, 
             class: "w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent",
-            step: 0.01, min: 0, placeholder: "0.00" %>
+            step: 0.0001, min: 0, placeholder: "0.0000" %>
       </div>
 
       <div>

--- a/db/migrate/20251030004116_increase_weight_range_precision.rb
+++ b/db/migrate/20251030004116_increase_weight_range_precision.rb
@@ -1,0 +1,6 @@
+class IncreaseWeightRangePrecision < ActiveRecord::Migration[8.0]
+  def change
+    change_column :rates, :min_range_lbs, :decimal, precision: 8, scale: 4, null: false
+    change_column :rates, :max_range_lbs, :decimal, precision: 8, scale: 4, null: false
+  end
+end


### PR DESCRIPTION
- Update database migration to change min_range_lbs and max_range_lbs from scale 2 to scale 4
- Update form inputs to support 0.0001 step increments
- Update CSV import documentation with 4 decimal examples
- Update placeholder text in forms to reflect 4 decimal precision