### PR TITLE
Fix DRI_REQUIRED error for Make Wellness company DRO-1

### DIFF
--- a/app/controllers/concerns/dri_authentication.rb
+++ b/app/controllers/concerns/dri_authentication.rb
@@ -24,6 +24,7 @@ private
       session[:dri] = dri
       Rails.logger.info "[DRI] Stored new DRI in session: #{dri}"
     elsif session[:dri].blank?
+      Rails.logger.warn "[DRI] Missing DRI - params[:dri]: #{params[:dri].inspect}, session[:dri]: #{session[:dri].inspect}, session_id: #{session.id}, request_path: #{request.path}"
       render_dri_error(
         message: "DRI parameter is required",
         code: "DRI_REQUIRED",

--- a/app/controllers/concerns/dri_authentication.rb
+++ b/app/controllers/concerns/dri_authentication.rb
@@ -24,7 +24,9 @@ private
       session[:dri] = dri
       Rails.logger.info "[DRI] Stored new DRI in session: #{dri}"
     elsif session[:dri].blank?
-      Rails.logger.warn "[DRI] Missing DRI - params[:dri]: #{params[:dri].inspect}, session[:dri]: #{session[:dri].inspect}, session_id: #{session.id}, request_path: #{request.path}"
+      Rails.logger.warn "[DRI] Missing DRI - params[:dri]: #{params[:dri].inspect}, " \
+                        "session[:dri]: #{session[:dri].inspect}, session_id: #{session.id}, " \
+                        "request_path: #{request.path}"
       render_dri_error(
         message: "DRI parameter is required",
         code: "DRI_REQUIRED",

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -4,7 +4,9 @@ class HomeController < ApplicationController
   def index
     # If we have a valid company/DRI session, redirect to shipping options
     if @company.present?
-      redirect_to shipping_options_path
+      # Include DRI in redirect URL as fallback in case cookies aren't working in iframe
+      dri = session[:dri] || params[:dri]
+      redirect_to shipping_options_path(dri: dri)
     end
     # Otherwise, show the landing page with the Fluid logo
   end


### PR DESCRIPTION
- Include DRI parameter in redirect URL as fallback when cookies aren't working in iframe
- Add enhanced logging to debug DRI session issues
- Ensures DRI is available even if session cookies fail in cross-origin iframe context