### PR TITLE
Fix callback duplication issues during uninstall/reinstall DRO-1

### DIFF
--- a/app/jobs/droplet_installed_job.rb
+++ b/app/jobs/droplet_installed_job.rb
@@ -45,14 +45,13 @@ class DropletInstalledJob < WebhookEventJob
       return
     end
 
-    register_active_callbacks
+    register_active_callbacks(company)
   end
 
 private
 
-  def register_active_callbacks
+  def register_active_callbacks(company)
     client = FluidClient.new
-    company = get_company
     installed_callback_ids = []
 
     # Clean up any existing callbacks before registering new ones

--- a/app/jobs/droplet_installed_job.rb
+++ b/app/jobs/droplet_installed_job.rb
@@ -55,6 +55,10 @@ private
     company = get_company
     installed_callback_ids = []
 
+    # Clean up any existing callbacks before registering new ones
+    # This prevents duplicates when reinstalling
+    cleanup_existing_callbacks(company)
+
     # Always register the shipping options callback - required for droplet functionality
     base_url = ENV.fetch("DROPLET_URL", "https://fluid-droplet-shipping-options-106074092699.europe-west1.run.app")
     required_callback = {
@@ -123,5 +127,26 @@ private
         "[DropletInstalledJob] Updated company with #{installed_callback_ids.length} callback IDs"
       )
     end
+  end
+
+  def cleanup_existing_callbacks(company)
+    # Delete any existing callbacks stored in the database
+    return unless company.installed_callback_ids.present?
+
+    client = FluidClient.new
+    company.installed_callback_ids.each do |callback_id|
+      begin
+        client.callback_registrations.delete(callback_id)
+        Rails.logger.info(
+          "[DropletInstalledJob] Cleaned up existing callback: #{callback_id}"
+        )
+      rescue => e
+        # Log but don't fail - callback might already be deleted
+        Rails.logger.warn(
+          "[DropletInstalledJob] Could not delete existing callback #{callback_id}: #{e.message}"
+        )
+      end
+    end
+    company.update(installed_callback_ids: [])
   end
 end

--- a/app/jobs/droplet_uninstalled_job.rb
+++ b/app/jobs/droplet_uninstalled_job.rb
@@ -27,18 +27,6 @@ class DropletUninstalledJob < WebhookEventJob
 private
 
   def delete_installed_callbacks(company)
-    return unless company.installed_callback_ids.present?
-
-    client = FluidClient.new
-
-    company.installed_callback_ids.each do |callback_id|
-      begin
-        client.callback_registrations.delete(callback_id)
-      rescue => e
-        Rails.logger.error("[DropletUninstalledJob] Failed to delete callback #{callback_id}: #{e.message}")
-      end
-    end
-
-    company.update(installed_callback_ids: [])
+    CallbackCleanupService.new(company).call
   end
 end

--- a/app/services/callback_cleanup_service.rb
+++ b/app/services/callback_cleanup_service.rb
@@ -1,0 +1,36 @@
+class CallbackCleanupService
+  def initialize(company)
+    @company = company
+  end
+
+  def call
+    # Use stored callback IDs to ensure we delete exactly what we registered
+    return unless @company.installed_callback_ids.present?
+
+    # Skip API calls in test environment, but still clear the stored IDs
+    unless Rails.env.test?
+      client = FluidClient.new
+      deleted_count = 0
+
+      @company.installed_callback_ids.each do |callback_id|
+        begin
+          client.callback_registrations.delete(callback_id)
+          deleted_count += 1
+          Rails.logger.info("[CallbackCleanupService] Deleted callback: #{callback_id}")
+        rescue => e
+          # Log but don't fail - callback might already be deleted
+          Rails.logger.warn(
+            "[CallbackCleanupService] Could not delete callback #{callback_id}: #{e.message}"
+          )
+        end
+      end
+
+      Rails.logger.info(
+        "[CallbackCleanupService] Deleted #{deleted_count} callback(s) for #{@company.fluid_shop}"
+      )
+    end
+
+    # Always clear the stored IDs, even in test environment
+    @company.update(installed_callback_ids: [])
+  end
+end

--- a/app/services/droplet_installation_service.rb
+++ b/app/services/droplet_installation_service.rb
@@ -74,7 +74,7 @@ private
     # Always register the shipping callback - required for droplet functionality
     base_url = ENV.fetch("DROPLET_URL", "https://fluid-droplet-shipping-options-106074092699.europe-west1.run.app")
     callback = {
-      definition_name: "update_cart_shipping",
+      definition_name: "shipping_options",
       url: "#{base_url}/callbacks/shipping_options",
       timeout_in_seconds: 10,
       active: true,

--- a/app/services/droplet_installation_service.rb
+++ b/app/services/droplet_installation_service.rb
@@ -65,8 +65,9 @@ private
     end
 
     # Clean up any existing callbacks before registering new ones
-    # This prevents duplicates when reinstalling
-    cleanup_existing_callbacks(company, installation_token)
+    # This is a defensive measure: if the previous uninstall failed or wasn't triggered,
+    # old callbacks would remain and cause duplicates on reinstall
+    CallbackCleanupService.new(company).call
 
     # Create a client with the installation token instead of company token
     client = FluidClient.new
@@ -118,26 +119,5 @@ private
     )
     Rails.logger.error(e.backtrace.join("\n"))
     raise e
-  end
-
-  def cleanup_existing_callbacks(company, installation_token)
-    # Delete any existing callbacks stored in the database
-    if company.installed_callback_ids.present?
-      client = FluidClient.new
-      company.installed_callback_ids.each do |callback_id|
-        begin
-          client.callback_registrations.delete(callback_id)
-          Rails.logger.info(
-            "[DropletInstallationService] Cleaned up existing callback: #{callback_id}"
-          )
-        rescue => e
-          # Log but don't fail - callback might already be deleted
-          Rails.logger.warn(
-            "[DropletInstallationService] Could not delete existing callback #{callback_id}: #{e.message}"
-          )
-        end
-      end
-      company.update(installed_callback_ids: [])
-    end
   end
 end

--- a/app/services/droplet_uninstallation_service.rb
+++ b/app/services/droplet_uninstallation_service.rb
@@ -51,31 +51,6 @@ private
   end
 
   def delete_installed_callbacks(company)
-    # Skip callback deletion in test environment
-    return if Rails.env.test?
-
-    # Use stored callback IDs to ensure we delete exactly what we registered
-    return unless company.installed_callback_ids.present?
-
-    client = FluidClient.new
-    deleted_count = 0
-
-    company.installed_callback_ids.each do |callback_id|
-      begin
-        client.callback_registrations.delete(callback_id)
-        deleted_count += 1
-        Rails.logger.info("[DropletUninstallationService] Deleted callback: #{callback_id}")
-      rescue => e
-        Rails.logger.error(
-          "[DropletUninstallationService] Failed to delete callback #{callback_id}: #{e.message}"
-        )
-      end
-    end
-
-    Rails.logger.info(
-      "[DropletUninstallationService] Deleted #{deleted_count} callback(s)"
-    )
-
-    company.update(installed_callback_ids: [])
+    CallbackCleanupService.new(company).call
   end
 end

--- a/app/services/droplet_uninstallation_service.rb
+++ b/app/services/droplet_uninstallation_service.rb
@@ -54,38 +54,27 @@ private
     # Skip callback deletion in test environment
     return if Rails.env.test?
 
+    # Use stored callback IDs to ensure we delete exactly what we registered
+    return unless company.installed_callback_ids.present?
+
     client = FluidClient.new
     deleted_count = 0
 
-    # Get all callback registrations and delete our shipping callback
-    begin
-      response = client.callback_registrations.get
-      registrations = response&.dig("callback_registrations") || []
-
-      registrations.each do |registration|
-        # Delete any callback with our definition name
-        if registration["definition_name"] == "update_cart_shipping"
-          callback_id = registration["uuid"]
-          begin
-            client.callback_registrations.delete(callback_id)
-            deleted_count += 1
-            Rails.logger.info("[DropletUninstallationService] Deleted callback: #{callback_id}")
-          rescue => e
-            Rails.logger.error(
-              "[DropletUninstallationService] Failed to delete callback #{callback_id}: #{e.message}"
-            )
-          end
-        end
+    company.installed_callback_ids.each do |callback_id|
+      begin
+        client.callback_registrations.delete(callback_id)
+        deleted_count += 1
+        Rails.logger.info("[DropletUninstallationService] Deleted callback: #{callback_id}")
+      rescue => e
+        Rails.logger.error(
+          "[DropletUninstallationService] Failed to delete callback #{callback_id}: #{e.message}"
+        )
       end
-
-      Rails.logger.info(
-        "[DropletUninstallationService] Deleted #{deleted_count} callback(s)"
-      )
-    rescue => e
-      Rails.logger.error(
-        "[DropletUninstallationService] Failed to list callbacks for deletion: #{e.message}"
-      )
     end
+
+    Rails.logger.info(
+      "[DropletUninstallationService] Deleted #{deleted_count} callback(s)"
+    )
 
     company.update(installed_callback_ids: [])
   end


### PR DESCRIPTION
# Fix callback duplication during uninstall/reinstall

## Problem
Shipping options callbacks were being duplicated when uninstalling and reinstalling the droplet. The uninstall process wasn't properly removing callbacks, and the install process wasn't cleaning up existing callbacks before registering new ones.

## Root Causes
1. **`DropletUninstallationService`** was fetching all callbacks and filtering by name instead of using stored callback IDs, which could miss callbacks or delete the wrong ones
2. **Installation services** didn't clean up existing callbacks before registering new ones, causing duplicates on reinstall
3. **Inconsistent approach** between `DropletUninstallationService` and `DropletUninstalledJob` (the job correctly used stored IDs)

## Solution
- **Fixed `DropletUninstallationService`** to use `company.installed_callback_ids` to delete exactly what was registered (matching `DropletUninstalledJob`)
- **Added `cleanup_existing_callbacks` method** to both `DropletInstallationService` and `DropletInstalledJob` to remove existing callbacks before registering new ones
- **Ensured both uninstall services** properly clear `installed_callback_ids` after deletion

## Changes
- `app/services/droplet_uninstallation_service.rb`: Now uses stored callback IDs instead of fetching all callbacks
- `app/services/droplet_installation_service.rb`: Added cleanup of existing callbacks before registration
- `app/jobs/droplet_installed_job.rb`: Added cleanup of existing callbacks before registration

## Testing
- Uninstall should now properly remove all registered callbacks using stored IDs
- Reinstall should clean up any existing callbacks before registering new ones, preventing duplicates

## Additional Fix
- **Standardized callback definition name** to `"shipping_options"` in both `DropletInstallationService` and `DropletInstalledJob` to match the endpoint URL and improve clarity

