### PR TITLE
Hotfix: Revert to correct callback definition name 'update_cart_shipp… DRO-1

### DIFF
--- a/app/jobs/droplet_installed_job.rb
+++ b/app/jobs/droplet_installed_job.rb
@@ -62,7 +62,7 @@ private
     # Always register the shipping options callback - required for droplet functionality
     base_url = ENV.fetch("DROPLET_URL", "https://fluid-droplet-shipping-options-106074092699.europe-west1.run.app")
     required_callback = {
-      definition_name: "shipping_options",
+      definition_name: "update_cart_shipping",
       url: "#{base_url}/callbacks/shipping_options",
       timeout_in_seconds: 10,
       active: true,

--- a/app/services/droplet_installation_service.rb
+++ b/app/services/droplet_installation_service.rb
@@ -75,7 +75,7 @@ private
     # Always register the shipping callback - required for droplet functionality
     base_url = ENV.fetch("DROPLET_URL", "https://fluid-droplet-shipping-options-106074092699.europe-west1.run.app")
     callback = {
-      definition_name: "shipping_options",
+      definition_name: "update_cart_shipping",
       url: "#{base_url}/callbacks/shipping_options",
       timeout_in_seconds: 10,
       active: true,


### PR DESCRIPTION
…ing'

The Fluid API was rejecting 'shipping_options' as an invalid definition name with a 422 error: 'is not a valid definition name'.

Production logs showed:
[DropletInstallationService] Error: Failed to register callback: 422 - {"errors":{"callback_registration":{"definition_name":["is not a valid definition name"]}}}

Reverted both DropletInstallationService and DropletInstalledJob to use the correct 'update_cart_shipping' definition name that was working before.