### PR TITLE
Fix duplicate callback registrations DRO-1

### DIFF
--- a/app/jobs/droplet_installed_job.rb
+++ b/app/jobs/droplet_installed_job.rb
@@ -74,6 +74,16 @@ private
         "#{required_callback[:definition_name]} at #{required_callback[:url]}"
       )
 
+      # Check if a callback with this definition already exists (should be prevented by cleanup, but extra safety)
+      existing_callbacks = client.callback_registrations.get(definition_name: required_callback[:definition_name])
+      if existing_callbacks && existing_callbacks["callback_registrations"]&.any?
+        Rails.logger.warn(
+          "[DropletInstalledJob] Found #{existing_callbacks['callback_registrations'].length} " \
+          "existing callback(s) for #{required_callback[:definition_name]} after cleanup. " \
+          "This should not happen - possible race condition or cleanup failure."
+        )
+      end
+
       response = client.callback_registrations.create(required_callback)
       if response && response["callback_registration"]["uuid"]
         installed_callback_ids << response["callback_registration"]["uuid"]

--- a/app/services/callback_cleanup_service.rb
+++ b/app/services/callback_cleanup_service.rb
@@ -4,25 +4,69 @@ class CallbackCleanupService
   end
 
   def call
-    # Use stored callback IDs to ensure we delete exactly what we registered
-    return unless @company.installed_callback_ids.present?
-
     # Skip API calls in test environment, but still clear the stored IDs
     unless Rails.env.test?
       client = FluidClient.new
       deleted_count = 0
 
-      @company.installed_callback_ids.each do |callback_id|
-        begin
-          client.callback_registrations.delete(callback_id)
-          deleted_count += 1
-          Rails.logger.info("[CallbackCleanupService] Deleted callback: #{callback_id}")
-        rescue => e
-          # Log but don't fail - callback might already be deleted
-          Rails.logger.warn(
-            "[CallbackCleanupService] Could not delete callback #{callback_id}: #{e.message}"
-          )
+      # First, delete callbacks tracked in the company record
+      if @company.installed_callback_ids.present?
+        @company.installed_callback_ids.each do |callback_id|
+          begin
+            client.callback_registrations.delete(callback_id)
+            deleted_count += 1
+            Rails.logger.info("[CallbackCleanupService] Deleted tracked callback: #{callback_id}")
+          rescue => e
+            # Log but don't fail - callback might already be deleted
+            Rails.logger.warn(
+              "[CallbackCleanupService] Could not delete tracked callback #{callback_id}: #{e.message}"
+            )
+          end
         end
+      end
+
+      # Second, fetch and delete any orphaned callbacks for this definition
+      # This handles cases where callbacks were created but not tracked
+      begin
+        base_url = ENV.fetch("DROPLET_URL", "https://fluid-droplet-shipping-options-106074092699.europe-west1.run.app")
+        expected_callback_url = "#{base_url}/callbacks/shipping_options"
+
+        response = client.callback_registrations.get(definition_name: "update_cart_shipping")
+        if response && response["callback_registrations"]
+          response["callback_registrations"].each do |reg|
+            callback_uuid = reg["uuid"]
+            callback_url = reg["url"]
+
+            # Skip if we already deleted this one
+            next if @company.installed_callback_ids&.include?(callback_uuid)
+
+            # IMPORTANT: Only delete callbacks that point to OUR app's URL
+            # This prevents accidentally deleting callbacks from other apps
+            unless callback_url == expected_callback_url
+              Rails.logger.info(
+                "[CallbackCleanupService] Skipping callback #{callback_uuid} - " \
+                "URL mismatch (ours: #{expected_callback_url}, theirs: #{callback_url})"
+              )
+              next
+            end
+
+            begin
+              client.callback_registrations.delete(callback_uuid)
+              deleted_count += 1
+              Rails.logger.info(
+                "[CallbackCleanupService] Deleted orphaned callback: #{callback_uuid}"
+              )
+            rescue => e
+              Rails.logger.warn(
+                "[CallbackCleanupService] Could not delete orphaned callback #{callback_uuid}: #{e.message}"
+              )
+            end
+          end
+        end
+      rescue => e
+        Rails.logger.warn(
+          "[CallbackCleanupService] Could not fetch existing callbacks: #{e.message}"
+        )
       end
 
       Rails.logger.info(


### PR DESCRIPTION
- Enhanced CallbackCleanupService to fetch and delete orphaned callbacks
- Added URL matching to only delete callbacks belonging to our app
- Added detection in DropletInstalledJob to log warnings if duplicates exist after cleanup
- Prevents duplicate callbacks from being created on reinstall