### PR TITLE
Add country-specific sort order for shipping methods DRO-185

### DIFF
--- a/app/services/shipping_calculation_service.rb
+++ b/app/services/shipping_calculation_service.rb
@@ -91,7 +91,7 @@ private
            .active
            .for_country(ship_to_country)
            .includes(:rates)
-           .order(:id)
+           .ordered_for_country(ship_to_country)
   end
 
   def success_result(shipping_options)

--- a/app/views/shared/_shipping_options_navigation.html.erb
+++ b/app/views/shared/_shipping_options_navigation.html.erb
@@ -1,26 +1,34 @@
 <div class="bg-white rounded-2xl shadow-sm border border-gray-100 p-2 mb-8">
   <nav class="flex space-x-1" id="shipping-nav-tabs">
-    <% 
+    <%
       is_overview = controller_name == 'shipping_options' && action_name == 'index'
       is_shipping_methods = controller_name == 'shipping_options' && action_name == 'shipping_methods'
+      is_sort_order = controller_name == 'shipping_options' && action_name == 'sort_order'
       is_rate_tables = controller_name == 'rates' && action_name == 'index' && !params[:shipping_option_id]
     %>
-    
-    <%= link_to shipping_options_path, 
+
+    <%= link_to shipping_options_path,
         class: "nav-tab flex items-center px-6 py-3 text-sm font-medium rounded-xl #{'bg-blue-50 text-blue-700 border border-blue-200' if is_overview} #{'text-gray-600 hover:text-gray-900 hover:bg-gray-50 transition-colors duration-200' unless is_overview}",
         data: { turbo_frame: "shipping_content", tab: "overview" } do %>
       <i class="fa-solid fa-grid-3 mr-2"></i>
       Overview
     <% end %>
-    
-    <%= link_to shipping_methods_shipping_options_path, 
+
+    <%= link_to shipping_methods_shipping_options_path,
         class: "nav-tab flex items-center px-6 py-3 text-sm font-medium rounded-xl #{'bg-blue-50 text-blue-700 border border-blue-200' if is_shipping_methods} #{'text-gray-600 hover:text-gray-900 hover:bg-gray-50 transition-colors duration-200' unless is_shipping_methods}",
         data: { turbo_frame: "shipping_content", tab: "shipping_methods" } do %>
       <i class="fa-solid fa-list mr-2"></i>
       Shipping Methods
     <% end %>
-    
-    <%= link_to rate_tables_path, 
+
+    <%= link_to sort_order_shipping_options_path,
+        class: "nav-tab flex items-center px-6 py-3 text-sm font-medium rounded-xl #{'bg-blue-50 text-blue-700 border border-blue-200' if is_sort_order} #{'text-gray-600 hover:text-gray-900 hover:bg-gray-50 transition-colors duration-200' unless is_sort_order}",
+        data: { turbo_frame: "shipping_content", tab: "sort_order" } do %>
+      <i class="fa-solid fa-sort mr-2"></i>
+      Sort Order
+    <% end %>
+
+    <%= link_to rate_tables_path,
         class: "nav-tab flex items-center px-6 py-3 text-sm font-medium rounded-xl #{'bg-blue-50 text-blue-700 border border-blue-200' if is_rate_tables} #{'text-gray-600 hover:text-gray-900 hover:bg-gray-50 transition-colors duration-200' unless is_rate_tables}",
         data: { turbo_frame: "shipping_content", tab: "rate_tables" } do %>
       <i class="fa-solid fa-arrows-up-down mr-2"></i>
@@ -76,42 +84,49 @@ function initializeNavigation() {
   // Function to determine active tab based on current content
   function determineActiveTabFromContent() {
     const currentPath = window.location.pathname;
-    
+
     // Check if we're on new/edit pages
     if (currentPath.includes('/new') || currentPath.includes('/edit')) {
       return null; // Don't mark any tab as active on new/edit pages
     }
-    
+
     // Check the content of the shipping_content frame
     const shippingContent = document.getElementById('shipping_content');
     if (shippingContent) {
       const contentText = shippingContent.textContent || shippingContent.innerText;
-      
+
       // More specific detection based on actual content
       // Check for more specific markers first to avoid false matches
-      
+
       // Check for Overview - most specific patterns first
       if (contentText.includes('Shipping Overview') || contentText.includes('Monitor your shipping') || contentText.includes('Active Methods') || contentText.includes('Configured Regions')) {
         return 'overview';
       }
-      
+
+      // Check for Sort Order page
+      if (contentText.includes('Shipping Method Sort Order') || contentText.includes('Drag and drop to reorder')) {
+        return 'sort_order';
+      }
+
       // Check for Shipping Methods - look for page title and specific content
       // Use more specific patterns to avoid false matches with rate tables mentions
-      if (contentText.includes('Manage and configure your shipping methods') || 
+      if (contentText.includes('Manage and configure your shipping methods') ||
           (contentText.includes('Shipping Methods') && !contentText.includes('Rate Tables Overview'))) {
         return 'shipping_methods';
       }
-      
+
       // Check for Rate Tables last - this is the least specific
-      if (contentText.includes('Rate Tables Overview') || contentText.includes('Add Rate Table') || 
+      if (contentText.includes('Rate Tables Overview') || contentText.includes('Add Rate Table') ||
           (contentText.includes('Rate Tables') && !contentText.includes('Shipping Methods'))) {
         return 'rate_tables';
       }
     }
-    
+
     // Fallback to URL-based detection
     if (currentPath.includes('/rates') || currentPath.includes('/rate_tables')) {
       return 'rate_tables';
+    } else if (currentPath.includes('/sort_order')) {
+      return 'sort_order';
     } else if (currentPath.includes('/shipping_methods')) {
       return 'shipping_methods';
     } else if (currentPath.includes('/shipping_options')) {

--- a/app/views/shipping_options/sort_order.html.erb
+++ b/app/views/shipping_options/sort_order.html.erb
@@ -1,0 +1,208 @@
+<% content_for :title, "Extended Shipping Options - Sort Order" %>
+
+<%= turbo_frame_tag "shipping_content" do %>
+  <div class="bg-white rounded-2xl shadow-sm border border-gray-100 p-8">
+    <div class="flex items-center justify-between mb-8">
+      <div>
+        <h2 class="text-2xl font-bold text-gray-900 mb-2">Shipping Method Sort Order</h2>
+        <p class="text-gray-600">Drag and drop to reorder shipping methods by country</p>
+      </div>
+    </div>
+
+    <% if @countries.any? %>
+      <!-- Country Selector -->
+      <div class="mb-6">
+        <label class="block text-sm font-medium text-gray-700 mb-2">Select Country</label>
+        <select id="country-selector" class="w-full max-w-xs px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500">
+          <% @countries.each do |country| %>
+            <option value="<%= country %>" <%= 'selected' if country == @selected_country %>><%= country %></option>
+          <% end %>
+        </select>
+      </div>
+
+      <!-- Sortable List -->
+      <% if @shipping_options.any? %>
+        <div id="sortable-shipping-methods" class="space-y-2" data-country="<%= @selected_country %>">
+          <% @shipping_options.each_with_index do |option, index| %>
+            <div class="sortable-item flex items-center bg-gray-50 border border-gray-200 rounded-lg p-4 cursor-move hover:bg-gray-100 transition-colors"
+                 data-id="<%= option.id %>"
+                 data-position="<%= option.position_for_country(@selected_country) || index + 1 %>">
+              <div class="drag-handle mr-4 text-gray-400">
+                <i class="fa-solid fa-grip-vertical text-lg"></i>
+              </div>
+              <div class="flex-1">
+                <div class="font-medium text-gray-900"><%= option.name %></div>
+                <div class="text-sm text-gray-500">
+                  <%= pluralize(option.delivery_time, 'day') %> - $<%= number_with_precision(option.starting_rate, precision: 2) %>
+                </div>
+              </div>
+              <div class="position-badge px-3 py-1 bg-blue-100 text-blue-800 rounded-full text-sm font-medium">
+                #<span class="position-number"><%= option.position_for_country(@selected_country) || index + 1 %></span>
+              </div>
+            </div>
+          <% end %>
+        </div>
+
+        <!-- Save Button -->
+        <div class="mt-6 flex justify-end">
+          <button id="save-sort-order"
+                  class="px-6 py-3 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  disabled>
+            <i class="fa-solid fa-save mr-2"></i>
+            Save Order
+          </button>
+        </div>
+      <% else %>
+        <div class="text-center py-12 text-gray-500">
+          <i class="fa-solid fa-box text-4xl mb-4"></i>
+          <p>No shipping methods available for <%= @selected_country %></p>
+        </div>
+      <% end %>
+    <% else %>
+      <div class="text-center py-12">
+        <div class="mx-auto h-12 w-12 text-gray-400">
+          <i class="fa-solid fa-box text-4xl"></i>
+        </div>
+        <h3 class="mt-2 text-sm font-medium text-gray-900">No shipping methods</h3>
+        <p class="mt-1 text-sm text-gray-500">Create shipping methods first to configure sort order.</p>
+        <div class="mt-6">
+          <%= link_to new_shipping_option_path, class: "inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700", data: { turbo_frame: "_top" } do %>
+            Add Method
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+<% end %>
+
+<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
+<script>
+function initializeSortOrder() {
+  const container = document.getElementById('sortable-shipping-methods');
+  const countrySelector = document.getElementById('country-selector');
+  const saveButton = document.getElementById('save-sort-order');
+
+  if (!container) return;
+
+  let hasChanges = false;
+
+  // Initialize SortableJS
+  const sortable = new Sortable(container, {
+    animation: 150,
+    handle: '.drag-handle',
+    ghostClass: 'bg-blue-50',
+    chosenClass: 'shadow-lg',
+    dragClass: 'opacity-50',
+    onEnd: function(evt) {
+      updatePositionNumbers();
+      hasChanges = true;
+      if (saveButton) saveButton.disabled = false;
+    }
+  });
+
+  // Update position numbers after drag
+  function updatePositionNumbers() {
+    const items = container.querySelectorAll('.sortable-item');
+    items.forEach((item, index) => {
+      const positionNumber = item.querySelector('.position-number');
+      if (positionNumber) {
+        positionNumber.textContent = index + 1;
+      }
+      item.dataset.position = index + 1;
+    });
+  }
+
+  // Country selector change handler
+  if (countrySelector) {
+    countrySelector.addEventListener('change', function() {
+      const selectedCountry = this.value;
+      // Get current URL and DRI parameter
+      const urlParams = new URLSearchParams(window.location.search);
+      const dri = urlParams.get('dri');
+      let newUrl = `/shipping_options/sort_order?country=${selectedCountry}`;
+      if (dri) {
+        newUrl += `&dri=${encodeURIComponent(dri)}`;
+      }
+      window.location.href = newUrl;
+    });
+  }
+
+  // Save button handler
+  if (saveButton) {
+    saveButton.addEventListener('click', async function() {
+      const items = container.querySelectorAll('.sortable-item');
+      const positions = Array.from(items).map((item, index) => ({
+        id: parseInt(item.dataset.id),
+        position: index + 1
+      }));
+
+      const countryCode = container.dataset.country;
+
+      // Get CSRF token
+      const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
+      // Get DRI from URL
+      const urlParams = new URLSearchParams(window.location.search);
+      const dri = urlParams.get('dri');
+
+      let updateUrl = '/shipping_options/update_sort_order';
+      if (dri) {
+        updateUrl += `?dri=${encodeURIComponent(dri)}`;
+      }
+
+      try {
+        saveButton.disabled = true;
+        saveButton.innerHTML = '<i class="fa-solid fa-spinner fa-spin mr-2"></i>Saving...';
+
+        const response = await fetch(updateUrl, {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CSRF-Token': csrfToken,
+            'Accept': 'application/json'
+          },
+          body: JSON.stringify({
+            country_code: countryCode,
+            positions: positions
+          })
+        });
+
+        const result = await response.json();
+
+        if (result.success) {
+          hasChanges = false;
+          saveButton.innerHTML = '<i class="fa-solid fa-check mr-2"></i>Saved!';
+          setTimeout(() => {
+            saveButton.innerHTML = '<i class="fa-solid fa-save mr-2"></i>Save Order';
+            saveButton.disabled = true;
+          }, 2000);
+        } else {
+          throw new Error(result.error || 'Failed to save');
+        }
+      } catch (error) {
+        console.error('Error saving sort order:', error);
+        saveButton.disabled = false;
+        saveButton.innerHTML = '<i class="fa-solid fa-save mr-2"></i>Save Order';
+        alert('Failed to save sort order. Please try again.');
+      }
+    });
+  }
+
+  // Warn before leaving with unsaved changes
+  window.addEventListener('beforeunload', function(e) {
+    if (hasChanges) {
+      e.preventDefault();
+      e.returnValue = '';
+    }
+  });
+}
+
+// Initialize on page load
+document.addEventListener('DOMContentLoaded', initializeSortOrder);
+document.addEventListener('turbo:load', initializeSortOrder);
+document.addEventListener('turbo:frame-load', function(e) {
+  if (e.target.id === 'shipping_content') {
+    initializeSortOrder();
+  }
+});
+</script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,8 @@ Rails.application.routes.draw do
     end
     collection do
       get :shipping_methods
+      get :sort_order
+      patch :update_sort_order
     end
   end
 

--- a/db/migrate/20260108200744_add_country_sort_positions_to_shipping_options.rb
+++ b/db/migrate/20260108200744_add_country_sort_positions_to_shipping_options.rb
@@ -1,0 +1,6 @@
+class AddCountrySortPositionsToShippingOptions < ActiveRecord::Migration[8.0]
+  def change
+    add_column :shipping_options, :country_sort_positions, :jsonb, default: {}
+    add_index :shipping_options, :country_sort_positions, using: :gin
+  end
+end


### PR DESCRIPTION
## Linear Ticket
[DRO-185](https://linear.app/fluid-commerce/issue/DRO-185/add-country-specific-sort-order-for-shipping-methods)

## Summary
- Add the ability for merchants to configure the display order of shipping methods on a per-country basis
- Implement drag-and-drop reordering UI in the admin panel via a new "Sort Order" tab
- Shipping methods returned to Fluid are now sorted by the country-specific position (fallback to database ID)

## Changes
- **Database**: Add `country_sort_positions` JSONB column to `shipping_options` table with GIN index
- **Model**: Add `ordered_for_country` scope, `position_for_country`/`set_position_for_country` methods, and auto-assignment of default positions
- **Service**: Update `ShippingCalculationService` to use country-specific ordering
- **Routes**: Add `sort_order` and `update_sort_order` collection routes
- **Controller**: Add `sort_order` and `update_sort_order` actions
- **Views**: Add new "Sort Order" tab to navigation and create `sort_order.html.erb` view with SortableJS

## Test plan
- [ ] Run `bin/rails db:migrate` to apply the migration
- [ ] Navigate to the "Sort Order" tab in the shipping options admin
- [ ] Select a country from the dropdown
- [ ] Drag and drop shipping methods to reorder them
- [ ] Click "Save Order" and verify the positions persist
- [ ] Verify shipping methods are returned in the new order via the callback endpoint
- [ ] Create a new shipping option and verify it gets default positions

🤖 Generated with [Claude Code](https://claude.com/claude-code)