### PR TITLE
fix: handle DRI mismatch on droplet reinstall

### DIFF
--- a/app/controllers/concerns/dri_authentication.rb
+++ b/app/controllers/concerns/dri_authentication.rb
@@ -115,12 +115,18 @@ private
   end
 
   # Attempts to find a company that may have been reinstalled by looking for
-  # recent installations with similar company identifiers
+  # the old DRI in their previous_dris history
   def find_potentially_reinstalled_company(old_dri)
-    # This is a placeholder for potential future enhancement
-    # We could log this for analytics to understand reinstallation patterns
     Rails.logger.info "[DRI] Checking for potential reinstallation related to: #{old_dri}"
-    nil
+
+    # Search for company where the old DRI exists in their previous_dris array
+    company = Company.where("previous_dris @> ?", [old_dri].to_json).first
+
+    if company
+      Rails.logger.info "[DRI] Found reinstalled company #{company.fluid_shop} with current DRI: #{company.droplet_installation_uuid}"
+    end
+
+    company
   end
 
   # Handles the case where we detected a company was reinstalled

--- a/app/controllers/concerns/dri_authentication.rb
+++ b/app/controllers/concerns/dri_authentication.rb
@@ -123,7 +123,8 @@ private
     company = Company.where("previous_dris @> ?", [old_dri].to_json).first
 
     if company
-      Rails.logger.info "[DRI] Found reinstalled company #{company.fluid_shop} with current DRI: #{company.droplet_installation_uuid}"
+      Rails.logger.info "[DRI] Found reinstalled company #{company.fluid_shop} " \
+                        "with current DRI: #{company.droplet_installation_uuid}"
     end
 
     company

--- a/app/controllers/concerns/dri_authentication.rb
+++ b/app/controllers/concerns/dri_authentication.rb
@@ -120,7 +120,7 @@ private
     Rails.logger.info "[DRI] Checking for potential reinstallation related to: #{old_dri}"
 
     # Search for company where the old DRI exists in their previous_dris array
-    company = Company.where("previous_dris @> ?", [old_dri].to_json).first
+    company = Company.where("previous_dris @> ?", [ old_dri ].to_json).first
 
     if company
       Rails.logger.info "[DRI] Found reinstalled company #{company.fluid_shop} " \

--- a/app/jobs/droplet_installed_job.rb
+++ b/app/jobs/droplet_installed_job.rb
@@ -18,12 +18,17 @@ class DropletInstalledJob < WebhookEventJob
 
     company = Company.find_by(fluid_shop: company_attributes["fluid_shop"]) || Company.new
 
-    # Log if this is a reinstallation
-    if company.persisted? && company.droplet_installation_uuid != company_attributes["droplet_installation_uuid"]
+    # Handle reinstallation: store old DRI before updating
+    if company.persisted? && company.droplet_installation_uuid.present? &&
+       company.droplet_installation_uuid != company_attributes["droplet_installation_uuid"]
       Rails.logger.info(
         "[DropletInstalledJob] Reinstallation detected for #{company.fluid_shop}. " \
         "Old DRI: #{company.droplet_installation_uuid}, New DRI: #{company_attributes['droplet_installation_uuid']}"
       )
+      # Store old DRI for lookup (keep last 5 to prevent unbounded growth)
+      old_dris = (company.previous_dris || []).dup
+      old_dris.unshift(company.droplet_installation_uuid) unless old_dris.include?(company.droplet_installation_uuid)
+      company.previous_dris = old_dris.first(5)
     end
 
     company.assign_attributes(company_attributes.slice(

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -11,7 +11,7 @@ class Company < ApplicationRecord
   scope :installed, -> { where(uninstalled_at: nil) }
   scope :uninstalled, -> { where.not(uninstalled_at: nil) }
 
-  after_initialize :set_default_installed_callback_ids, if: :new_record?
+  after_initialize :set_defaults, if: :new_record?
 
   store_accessor :settings, :exigo_db_server, :exigo_db_name, :exigo_db_user, :exigo_db_password,
                  :exigo_subscription_id, :free_shipping_for_subscribers
@@ -54,7 +54,8 @@ class Company < ApplicationRecord
 
 private
 
-  def set_default_installed_callback_ids
+  def set_defaults
     self.installed_callback_ids ||= []
+    self.previous_dris ||= []
   end
 end

--- a/db/migrate/20260114210000_add_previous_dris_to_companies.rb
+++ b/db/migrate/20260114210000_add_previous_dris_to_companies.rb
@@ -1,0 +1,6 @@
+class AddPreviousDrisToCompanies < ActiveRecord::Migration[8.0]
+  def change
+    add_column :companies, :previous_dris, :jsonb, default: [], null: false
+    add_index :companies, :previous_dris, using: :gin
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -48,11 +48,13 @@ ActiveRecord::Schema[8.0].define(version: 2026_02_13_115739) do
     t.datetime "updated_at", null: false
     t.string "droplet_installation_uuid"
     t.jsonb "installed_callback_ids", default: []
+    t.jsonb "previous_dris", default: [], null: false
     t.index ["active"], name: "index_companies_on_active"
     t.index ["authentication_token"], name: "index_companies_on_authentication_token", unique: true
     t.index ["company_droplet_uuid"], name: "index_companies_on_company_droplet_uuid"
     t.index ["fluid_company_id"], name: "index_companies_on_fluid_company_id"
     t.index ["fluid_shop"], name: "index_companies_on_fluid_shop"
+    t.index ["previous_dris"], name: "index_companies_on_previous_dris", using: :gin
   end
 
   create_table "events", force: :cascade do |t|


### PR DESCRIPTION
## Summary
- Adds `previous_dris` column to track historical DRIs when a droplet is reinstalled
- Updates `DropletInstallationService` and `DropletInstalledJob` to store old DRI before updating
- Updates `DriAuthentication` concern to look up companies by previous DRIs
- Users with stale sessions now get a helpful "DROPLET_REINSTALLED" message instead of "DRI_NOT_FOUND"

## Problem
When a droplet is reinstalled, Fluid generates a new DRI. Users who had the droplet open in their browser still have the old DRI in their session. When they interact with the droplet, the lookup by `droplet_installation_uuid` fails because the company now has a new DRI.

## Solution
1. When reinstall is detected, store the old DRI in a `previous_dris` array (keeps last 5)
2. When looking up a company by DRI fails, search the `previous_dris` array
3. If found, return a helpful message telling the user to refresh from Fluid admin

## Test plan
- [ ] Run migration: `rails db:migrate`
- [ ] Test fresh install - should work as before
- [ ] Test reinstall - old DRI should be stored in `previous_dris`
- [ ] Test accessing with old DRI after reinstall - should show "DROPLET_REINSTALLED" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)