### PR TITLE
Fix webhook authentication to prevent cross-contamination DRO-202

### DIFF
--- a/test/controllers/webhooks_controller_test.rb
+++ b/test/controllers/webhooks_controller_test.rb
@@ -2,15 +2,96 @@ require "test_helper"
 
 
 describe WebhooksController do
-  fixtures(:companies)
+  fixtures(:companies, :settings)
+
+  let(:valid_droplet_uuid) { Setting.droplet.uuid }
 
   describe "droplet events" do
-    it "handles droplet installed event" do
+    describe "droplet_uuid validation" do
+      it "rejects droplet installed event with wrong droplet_uuid" do
+        company_data = {
+          fluid_shop: "test-shop",
+          name: "Test Company",
+          fluid_company_id: 123456,
+          droplet_uuid: "wrong-droplet-uuid",
+          authentication_token: "secret-token-123",
+          webhook_verification_token: "verify-token-456",
+        }
+
+        post webhook_url, params: {
+          resource: "droplet",
+          event: "installed",
+          company: company_data,
+        }, as: :json
+
+        _(response.status).must_equal 401
+        _(JSON.parse(response.body)["error"]).must_equal "Unauthorized - wrong droplet"
+      end
+
+      it "rejects droplet uninstalled event with wrong droplet_uuid" do
+        company = companies(:acme)
+
+        post webhook_url, params: {
+          resource: "droplet",
+          event: "uninstalled",
+          company: {
+            droplet_installation_uuid: company.droplet_installation_uuid,
+            fluid_company_id: company.fluid_company_id,
+            droplet_uuid: "wrong-droplet-uuid",
+          },
+        }, as: :json
+
+        _(response.status).must_equal 401
+        _(JSON.parse(response.body)["error"]).must_equal "Unauthorized - wrong droplet"
+      end
+
+      it "rejects droplet installed event with missing droplet_uuid" do
+        company_data = {
+          fluid_shop: "test-shop",
+          name: "Test Company",
+          fluid_company_id: 123456,
+          # droplet_uuid intentionally omitted
+          authentication_token: "secret-token-123",
+          webhook_verification_token: "verify-token-456",
+        }
+
+        post webhook_url, params: {
+          resource: "droplet",
+          event: "installed",
+          company: company_data,
+        }, as: :json
+
+        _(response.status).must_equal 401
+        _(JSON.parse(response.body)["error"]).must_equal "Unauthorized - wrong droplet"
+      end
+
+      it "rejects droplet installed event with nil droplet_uuid" do
+        company_data = {
+          fluid_shop: "test-shop",
+          name: "Test Company",
+          fluid_company_id: 123456,
+          droplet_uuid: nil,
+          authentication_token: "secret-token-123",
+          webhook_verification_token: "verify-token-456",
+        }
+
+        post webhook_url, params: {
+          resource: "droplet",
+          event: "installed",
+          company: company_data,
+        }, as: :json
+
+        _(response.status).must_equal 401
+        _(JSON.parse(response.body)["error"]).must_equal "Unauthorized - wrong droplet"
+      end
+    end
+
+    it "handles droplet installed event with correct droplet_uuid" do
       company_data = {
         fluid_shop: "test-shop",
         name: "Test Company",
         fluid_company_id: 123456,
-        droplet_uuid: "abc-123-xyz",
+        droplet_uuid: valid_droplet_uuid,
         authentication_token: "secret-token-123",
         webhook_verification_token: "verify-token-456",
       }
@@ -29,13 +110,12 @@ describe WebhooksController do
       _(company.fluid_shop).must_equal "test-shop"
       _(company.name).must_equal "Test Company"
       _(company.fluid_company_id).must_equal 123456
-      _(company.company_droplet_uuid).must_equal "abc-123-xyz"
+      _(company.company_droplet_uuid).must_equal valid_droplet_uuid
       _(company).must_be :active?
     end
 
-    it "handles droplet uninstalled event with valid authentication token in header" do
+    it "handles droplet uninstalled event with correct droplet_uuid" do
       company = companies(:acme)
-      webhook_auth_token = Setting.fluid_webhook.auth_token
 
       post webhook_url, params: {
         resource: "droplet",
@@ -43,8 +123,9 @@ describe WebhooksController do
         company: {
           droplet_installation_uuid: company.droplet_installation_uuid,
           fluid_company_id: company.fluid_company_id,
+          droplet_uuid: valid_droplet_uuid,
         },
-      }, headers: { "AUTH_TOKEN" => webhook_auth_token }, as: :json
+      }, as: :json
 
       _(response.status).must_equal 202
 
@@ -56,7 +137,6 @@ describe WebhooksController do
 
     it "updates existing company on droplet installed event" do
       company = companies(:acme)
-      webhook_auth_token = Setting.fluid_webhook.auth_token
 
       post webhook_url, params: {
         resource: "droplet",
@@ -65,11 +145,11 @@ describe WebhooksController do
           fluid_shop: company.fluid_shop,
           name: "Updated Company Name",
           fluid_company_id: company.fluid_company_id,
-          droplet_uuid: "updated-uuid-456",
+          droplet_uuid: valid_droplet_uuid,
           authentication_token: "updated-token-456",
           webhook_verification_token: company.webhook_verification_token,
         },
-      }, headers: { "AUTH_TOKEN" => webhook_auth_token }, as: :json
+      }, as: :json
 
       _(response.status).must_equal 202
 
@@ -77,16 +157,18 @@ describe WebhooksController do
 
       company.reload
       _(company.name).must_equal "Updated Company Name"
-      _(company.company_droplet_uuid).must_equal "updated-uuid-456"
+      _(company.company_droplet_uuid).must_equal valid_droplet_uuid
       _(company.authentication_token).must_equal "updated-token-456"
       _(company).must_be :active?
     end
+  end
 
+  describe "non-droplet events authentication" do
     it "rejects event when webhook verification token is invalid" do
       company = companies(:acme)
       post webhook_url, params: {
-        resource: "droplet",
-        event: "uninstalled",
+        resource: "order",
+        event: "created",
         company: {
           droplet_installation_uuid: company.droplet_installation_uuid,
           fluid_company_id: company.fluid_company_id,
@@ -101,8 +183,8 @@ describe WebhooksController do
     it "rejects event when authentication token in header is invalid" do
       company = companies(:acme)
       post webhook_url, params: {
-        resource: "droplet",
-        event: "uninstalled",
+        resource: "order",
+        event: "created",
         company: {
           droplet_installation_uuid: company.droplet_installation_uuid,
           fluid_company_id: company.fluid_company_id,
@@ -117,8 +199,8 @@ describe WebhooksController do
       webhook_auth_token = Setting.fluid_webhook.auth_token
 
       post webhook_url, params: {
-        resource: "droplet",
-        event: "uninstalled",
+        resource: "order",
+        event: "created",
         company: {
           droplet_installation_uuid: "non-existent-uuid",
           fluid_company_id: 999999,
@@ -130,47 +212,35 @@ describe WebhooksController do
       _(JSON.parse(response.body)["error"]).must_equal "Company not found"
     end
 
-    it "relies on company payload for authentication if auth token is not provided" do
+    it "accepts global webhook auth token" do
       company = companies(:acme)
       webhook_auth_token = Setting.fluid_webhook.auth_token
 
       post webhook_url, params: {
-        resource: "droplet",
-        event: "uninstalled",
+        resource: "order",
+        event: "created",
         company: {
           droplet_installation_uuid: company.droplet_installation_uuid,
           fluid_company_id: company.fluid_company_id,
-          webhook_verification_token: company.webhook_verification_token,
         },
       }, headers: { "AUTH_TOKEN" => webhook_auth_token }, as: :json
 
-      _(response.status).must_equal 202
-
-      perform_enqueued_jobs
-
-      company.reload
-      _(company.uninstalled_at).wont_be_nil
+      _(response.status).must_equal 204
     end
 
-    it "bypasses verification for droplet installed event" do
-      company_data = {
-        fluid_shop: "new-shop",
-        name: "New Company",
-        fluid_company_id: 999999,
-        droplet_uuid: "new-uuid-123",
-        authentication_token: "new-secret-token",
-        webhook_verification_token: "new-verify-token",
-      }
-
-      # No webhook_verification_token provided, but should still succeed
+    it "accepts company webhook_verification_token in header" do
+      company = companies(:acme)
 
       post webhook_url, params: {
-        resource: "droplet",
-        event: "installed",
-        company: company_data,
-      }, as: :json
+        resource: "order",
+        event: "created",
+        company: {
+          droplet_installation_uuid: company.droplet_installation_uuid,
+          fluid_company_id: company.fluid_company_id,
+        },
+      }, headers: { "AUTH_TOKEN" => company.webhook_verification_token }, as: :json
 
-      _(response.status).must_equal 202
+      _(response.status).must_equal 204
     end
   end
 


### PR DESCRIPTION
## Summary

- Fixes critical issue where droplet install/uninstall webhooks from other droplets were being processed, causing invalid DRI errors (e.g., Neumi's `DRI_NOT_FOUND` error)
- Adds `validate_droplet_authorization` to verify incoming webhooks match this droplet's UUID
- Uses timing-safe token comparisons to prevent timing attacks
- Accepts both global webhook token AND company-specific `webhook_verification_token`

## Root Cause

All 14 droplet webhooks registered to the same owner company (Droplet Inc) were being sent to ALL droplet services. Without `droplet_uuid` validation, each service processed webhooks meant for other droplets, causing race conditions and data corruption.

## Changes

| File | Change |
|------|--------|
| `application_controller.rb` | Added `validate_droplet_authorization` method |
| `webhooks_controller.rb` | Fixed before_actions, added timing-safe token comparison |
| `webhooks_controller_test.rb` | Added tests for droplet_uuid validation and edge cases |

## Test plan

- [ ] Verify droplet installed webhook with correct `droplet_uuid` succeeds
- [ ] Verify droplet installed webhook with wrong `droplet_uuid` returns 401
- [ ] Verify droplet uninstalled webhook with correct `droplet_uuid` succeeds  
- [ ] Verify droplet uninstalled webhook with wrong `droplet_uuid` returns 401
- [ ] Verify non-droplet webhooks still work with global auth token
- [ ] Verify non-droplet webhooks work with company's `webhook_verification_token`
- [ ] Deploy to staging and test Neumi reinstall flow

🤖 Generated with [Claude Code](https://claude.ai/code)