### PR TITLE
Add SENTRY_DSN to production Terraform config

### DIFF
--- a/terraform/environment/production/terraform.tfvars
+++ b/terraform/environment/production/terraform.tfvars
@@ -35,5 +35,6 @@ environment_variables_cloud_run = {
   "RACK_ENV"            = "production",
   "RAILS_ENV"           = "production",
   "RAILS_LOG_TO_STDOUT" = "enabled",
-  "RAILS_MASTER_KEY"    = ""
+  "RAILS_MASTER_KEY"    = "",
+  "SENTRY_DSN"          = "https://bf840ff3a60ff103deac474b04208bb1@o553113.ingest.us.sentry.io/4510885897830400"
 }


### PR DESCRIPTION
## Summary

- Adds SENTRY_DSN to environment_variables_cloud_run in production tfvars
- Sentry project droplet-shipping-options created in the fluid org
- SENTRY_DSN already set on Cloud Run via gcloud run services update

## Test plan

- [ ] Verify terraform plan shows no unexpected changes
- [ ] Confirm Sentry receives events from shipping-options

Generated with Claude Code