### PR TITLE
Add upsert support to CSV rate import

### DIFF
--- a/app/services/rate_csv_import_service.rb
+++ b/app/services/rate_csv_import_service.rb
@@ -1,7 +1,7 @@
 require "csv"
 
 class RateCsvImportService
-  attr_reader :company, :file, :errors, :success_count, :row_errors, :auto_correctable_errors
+  attr_reader :company, :file, :errors, :success_count, :replaced_count, :row_errors, :auto_correctable_errors
 
   def initialize(company:, file:)
     @company = company
@@ -10,6 +10,7 @@ class RateCsvImportService
     @row_errors = []
     @auto_correctable_errors = []
     @success_count = 0
+    @replaced_count = 0
   end
 
   def call(apply_corrections: false)
@@ -99,44 +100,59 @@ private
   end
 
   def import_rates(csv_data, apply_corrections: false)
-    # Pre-scan CSV to create missing shipping options
-    ensure_shipping_options_exist(csv_data)
-
     # Preprocess and sort CSV data for proper import order
     sorted_data = preprocess_and_sort_csv(csv_data)
 
-    # First pass: Validate all rows without saving
-    validated_rates = []
-
-    sorted_data.each do |row_data|
-      row_number = row_data[:original_row_number]
-      row = row_data[:row]
-
-      begin
-        rate, error = validate_rate_row(row, row_number, validated_rates, apply_corrections: apply_corrections)
-        if error
-          @row_errors << error
-        elsif rate
-          validated_rates << { rate: rate, row_number: row_number }
-        end
-      rescue StandardError => e
-        @row_errors << { row: row_number, errors: [ e.message ], data: row.to_h }
-      end
-    end
-
-    # If any errors, don't import anything
-    # (When apply_corrections is true, auto-correctable errors are already fixed)
-    # But we still need to check for non-correctable errors
-    if @row_errors.any?
-      Rails.logger.warn "[CSV Import] Found #{@row_errors.count} errors after validation"
-      @row_errors.each do |error|
-        Rails.logger.warn "[CSV Import] Row #{error[:row]}: #{error[:errors].join(', ')}"
-      end
-      return
-    end
-
-    # Second pass: All validations passed, save all records in a transaction
+    # Everything happens in a single transaction so that shipping option
+    # changes, rate deletions, and new rate inserts all roll back together
+    # if anything fails.
     ActiveRecord::Base.transaction do
+      # Create or update shipping options for methods referenced in the CSV
+      ensure_shipping_options_exist(csv_data)
+
+      # Determine which (shipping_option, country, region) combos are in the
+      # CSV so we can replace existing rates for those locations.
+      locations_to_replace = collect_locations_to_replace(sorted_data)
+
+      # Delete existing rates for locations present in the CSV.
+      # This turns the import into an upsert: locations in the CSV get fully
+      # replaced, while locations NOT in the CSV remain untouched.
+      @replaced_count = delete_existing_rates_for_locations(locations_to_replace)
+
+      if @replaced_count > 0
+        Rails.logger.info "[CSV Import] Replaced #{@replaced_count} existing rate(s) for #{locations_to_replace.size} location(s)"
+      end
+
+      # Validate all rows (now that conflicting DB records are removed)
+      validated_rates = []
+
+      sorted_data.each do |row_data|
+        row_number = row_data[:original_row_number]
+        row = row_data[:row]
+
+        begin
+          rate, error = validate_rate_row(row, row_number, validated_rates, apply_corrections: apply_corrections)
+          if error
+            @row_errors << error
+          elsif rate
+            validated_rates << { rate: rate, row_number: row_number }
+          end
+        rescue StandardError => e
+          @row_errors << { row: row_number, errors: [ e.message ], data: row.to_h }
+        end
+      end
+
+      # If any errors, roll back everything (deletes + shipping option changes)
+      if @row_errors.any?
+        Rails.logger.warn "[CSV Import] Found #{@row_errors.count} errors after validation"
+        @row_errors.each do |error|
+          Rails.logger.warn "[CSV Import] Row #{error[:row]}: #{error[:errors].join(', ')}"
+        end
+        @replaced_count = 0
+        raise ActiveRecord::Rollback
+      end
+
+      # All validations passed — save all new rates
       validated_rates.each do |item|
         item[:rate].save!
         @success_count += 1
@@ -372,6 +388,48 @@ private
     end
   end
 
+  # Collect unique (shipping_option_id, country, region) combos from the CSV
+  # so we know which existing rates to replace.
+  def collect_locations_to_replace(sorted_data)
+    locations = Set.new
+
+    sorted_data.each do |row_data|
+      row = row_data[:row]
+      method_name = row[:shipping_method]&.strip
+      next if method_name.blank?
+
+      shipping_option = company.shipping_options.find_by(name: method_name)
+      next unless shipping_option
+
+      country = row[:country]&.strip&.upcase
+      region = row[:region]&.strip.presence
+
+      locations.add([ shipping_option.id, country, region ])
+    end
+
+    locations.to_a
+  end
+
+  # Delete existing rates for the given location combos.
+  # Returns the number of rates deleted.
+  def delete_existing_rates_for_locations(locations)
+    return 0 if locations.empty?
+
+    total_deleted = 0
+
+    locations.each do |shipping_option_id, country, region|
+      deleted = Rate.where(
+        shipping_option_id: shipping_option_id,
+        country: country,
+        region: region
+      ).delete_all
+
+      total_deleted += deleted
+    end
+
+    total_deleted
+  end
+
   def find_shipping_option(name, row_number)
     return nil if name.blank?
 
@@ -449,10 +507,17 @@ private
   end
 
   def success
+    message = if @replaced_count > 0
+      "Successfully imported #{@success_count} rate(s) (#{@replaced_count} existing rate(s) replaced)"
+    else
+      "Successfully imported #{@success_count} rate(s)"
+    end
+
     {
       success: true,
-      message: "Successfully imported #{@success_count} rate(s)",
+      message: message,
       imported_count: @success_count,
+      replaced_count: @replaced_count,
     }
   end
 

--- a/app/services/rate_csv_import_service.rb
+++ b/app/services/rate_csv_import_service.rb
@@ -128,7 +128,8 @@ private
       @replaced_count, @affected_shipping_option_ids = delete_existing_rates_for_locations(locations_to_replace)
 
       if @replaced_count > 0
-        Rails.logger.info "[CSV Import] Replaced #{@replaced_count} existing rate(s) for #{locations_to_replace.size} location(s)"
+        Rails.logger.info "[CSV Import] Replaced #{@replaced_count} existing rate(s) " \
+                          "for #{locations_to_replace.size} location(s)"
       end
 
       # Validate all rows (now that conflicting DB records are removed)
@@ -437,7 +438,7 @@ private
     end
     combined = scopes.reduce { |chain, scope| chain.or(scope) }
 
-    affected_ids = locations.map(&:first).to_set
+    affected_ids = locations.to_set(&:first)
     total_deleted = combined.delete_all
 
     [ total_deleted, affected_ids ]
@@ -530,7 +531,7 @@ private
       success: true,
       message: message,
       imported_count: @success_count,
-      replaced_count: @replaced_count
+      replaced_count: @replaced_count,
     }
   end
 
@@ -541,7 +542,7 @@ private
       message: message,
       errors: @errors,
       row_errors: @row_errors,
-      imported_count: 0
+      imported_count: 0,
     }
   end
 end

--- a/app/views/rates/import.html.erb
+++ b/app/views/rates/import.html.erb
@@ -137,7 +137,7 @@
       CSV Format Requirements
     </h3>
     <div class="text-sm text-blue-800 space-y-2">
-      <p>Your CSV file must include the following columns (in any order). Importing will <strong>replace all existing rates</strong> for each shipping method + country + region combination included in the CSV. Rates for locations not in the CSV will remain unchanged.</p>
+      <p>Your CSV file must include the following columns (in any order). Importing will <strong>replace existing rates</strong> for each shipping method + country + region combination included in the CSV. Rates for locations not in the CSV will remain unchanged.</p>
       <ul class="list-disc list-inside ml-4 space-y-1">
         <li><strong>shipping_method</strong> - Name of an existing shipping method</li>
         <li><strong>country</strong> - 2-letter country code (e.g., US, CA, MX)</li>

--- a/app/views/rates/import.html.erb
+++ b/app/views/rates/import.html.erb
@@ -137,7 +137,7 @@
       CSV Format Requirements
     </h3>
     <div class="text-sm text-blue-800 space-y-2">
-      <p>Your CSV file must include the following columns (in any order):</p>
+      <p>Your CSV file must include the following columns (in any order). Importing will <strong>replace all existing rates</strong> for each shipping method + country + region combination included in the CSV. Rates for locations not in the CSV will remain unchanged.</p>
       <ul class="list-disc list-inside ml-4 space-y-1">
         <li><strong>shipping_method</strong> - Name of an existing shipping method</li>
         <li><strong>country</strong> - 2-letter country code (e.g., US, CA, MX)</li>

--- a/test/services/rate_csv_import_service_test.rb
+++ b/test/services/rate_csv_import_service_test.rb
@@ -445,8 +445,12 @@ class RateCsvImportServiceTest < ActiveSupport::TestCase
 
   test "should replace existing rates for the same shipping option, country, and region" do
     # Create existing rates for Express Shipping, US, CA
-    @shipping_option.rates.create!(country: "US", region: "CA", min_range_lbs: 0, max_range_lbs: 5, flat_rate: 10.00, min_charge: 5.00)
-    @shipping_option.rates.create!(country: "US", region: "CA", min_range_lbs: 5, max_range_lbs: 10, flat_rate: 15.00, min_charge: 8.00)
+    @shipping_option.rates.create!(
+      country: "US", region: "CA", min_range_lbs: 0, max_range_lbs: 5, flat_rate: 10.00, min_charge: 5.00
+    )
+    @shipping_option.rates.create!(
+      country: "US", region: "CA", min_range_lbs: 5, max_range_lbs: 10, flat_rate: 15.00, min_charge: 8.00
+    )
 
     assert_equal 2, @shipping_option.rates.where(country: "US", region: "CA").count
 
@@ -476,8 +480,12 @@ class RateCsvImportServiceTest < ActiveSupport::TestCase
 
   test "should not affect rates for locations not in the CSV" do
     # Create rates for two locations
-    @shipping_option.rates.create!(country: "US", region: "CA", min_range_lbs: 0, max_range_lbs: 10, flat_rate: 10.00, min_charge: 5.00)
-    @shipping_option.rates.create!(country: "US", region: "NY", min_range_lbs: 0, max_range_lbs: 10, flat_rate: 12.00, min_charge: 6.00)
+    @shipping_option.rates.create!(
+      country: "US", region: "CA", min_range_lbs: 0, max_range_lbs: 10, flat_rate: 10.00, min_charge: 5.00
+    )
+    @shipping_option.rates.create!(
+      country: "US", region: "NY", min_range_lbs: 0, max_range_lbs: 10, flat_rate: 12.00, min_charge: 6.00
+    )
 
     # Only import for CA — NY should remain untouched
     csv_content = <<~CSV
@@ -508,7 +516,9 @@ class RateCsvImportServiceTest < ActiveSupport::TestCase
 
   test "should rollback replaced rates when validation fails" do
     # Create existing rate
-    @shipping_option.rates.create!(country: "US", region: "TX", min_range_lbs: 0, max_range_lbs: 10, flat_rate: 10.00, min_charge: 5.00)
+    @shipping_option.rates.create!(
+      country: "US", region: "TX", min_range_lbs: 0, max_range_lbs: 10, flat_rate: 10.00, min_charge: 5.00
+    )
 
     # Import with an invalid row — everything should rollback
     csv_content = <<~CSV
@@ -532,7 +542,9 @@ class RateCsvImportServiceTest < ActiveSupport::TestCase
 
   test "should handle mix of new locations and replacement locations" do
     # Create existing rate for US/CA
-    @shipping_option.rates.create!(country: "US", region: "CA", min_range_lbs: 0, max_range_lbs: 10, flat_rate: 10.00, min_charge: 5.00)
+    @shipping_option.rates.create!(
+      country: "US", region: "CA", min_range_lbs: 0, max_range_lbs: 10, flat_rate: 10.00, min_charge: 5.00
+    )
 
     # Import replaces US/CA and adds new US/FL
     csv_content = <<~CSV
@@ -563,9 +575,13 @@ class RateCsvImportServiceTest < ActiveSupport::TestCase
 
   test "should treat country-level rates (nil region) separately from regional rates" do
     # Create country-level rate (no region)
-    @shipping_option.rates.create!(country: "US", region: nil, min_range_lbs: 0, max_range_lbs: 10, flat_rate: 5.00, min_charge: 2.00)
+    @shipping_option.rates.create!(
+      country: "US", region: nil, min_range_lbs: 0, max_range_lbs: 10, flat_rate: 5.00, min_charge: 2.00
+    )
     # Create regional rate
-    @shipping_option.rates.create!(country: "US", region: "CA", min_range_lbs: 0, max_range_lbs: 10, flat_rate: 10.00, min_charge: 5.00)
+    @shipping_option.rates.create!(
+      country: "US", region: "CA", min_range_lbs: 0, max_range_lbs: 10, flat_rate: 10.00, min_charge: 5.00
+    )
 
     # Only import country-level — regional should be untouched
     csv_content = <<~CSV
@@ -624,7 +640,9 @@ class RateCsvImportServiceTest < ActiveSupport::TestCase
   end
 
   test "should replace existing rates when applying auto-corrections" do
-    @shipping_option.rates.create!(country: "US", region: "CA", min_range_lbs: 0, max_range_lbs: 10, flat_rate: 10.00, min_charge: 5.00)
+    @shipping_option.rates.create!(
+      country: "US", region: "CA", min_range_lbs: 0, max_range_lbs: 10, flat_rate: 10.00, min_charge: 5.00
+    )
 
     # CSV with an oversized weight value that is auto-correctable
     csv_content = <<~CSV
@@ -658,7 +676,9 @@ class RateCsvImportServiceTest < ActiveSupport::TestCase
   end
 
   test "success message includes replaced count when rates were replaced" do
-    @shipping_option.rates.create!(country: "US", region: "CA", min_range_lbs: 0, max_range_lbs: 10, flat_rate: 10.00, min_charge: 5.00)
+    @shipping_option.rates.create!(
+      country: "US", region: "CA", min_range_lbs: 0, max_range_lbs: 10, flat_rate: 10.00, min_charge: 5.00
+    )
 
     csv_content = <<~CSV
       shipping_method,country,region,min_range_lbs,max_range_lbs,flat_rate,min_charge

--- a/test/services/rate_csv_import_service_test.rb
+++ b/test/services/rate_csv_import_service_test.rb
@@ -277,7 +277,7 @@ class RateCsvImportServiceTest < ActiveSupport::TestCase
     assert_equal 10, rates.third.min_range_lbs
   end
 
-  test "should detect overlapping weight ranges" do
+  test "should replace existing rates instead of failing on overlap with existing DB rates" do
     # Create first rate
     @shipping_option.rates.create!(
       country: "US",
@@ -288,9 +288,32 @@ class RateCsvImportServiceTest < ActiveSupport::TestCase
       min_charge: 5.00
     )
 
-    # Try to import overlapping rate
+    # Import a rate for the same location — with upsert, existing rates are
+    # replaced so overlaps with DB records no longer cause failures.
     csv_content = <<~CSV
       shipping_method,country,region,min_range_lbs,max_range_lbs,flat_rate,min_charge
+      Express Shipping,US,TX,0,15,14.99,10.00
+    CSV
+
+    file = create_csv_file(csv_content)
+    service = RateCsvImportService.new(company: @company, file: file)
+
+    result = service.call
+
+    assert result[:success]
+    assert_equal 1, result[:imported_count]
+    assert_equal 1, result[:replaced_count]
+
+    tx_rates = @shipping_option.rates.where(country: "US", region: "TX")
+    assert_equal 1, tx_rates.count
+    assert_equal 14.99, tx_rates.first.flat_rate
+  end
+
+  test "should detect overlapping weight ranges within the same CSV batch" do
+    # Overlapping ranges within the CSV itself should still fail
+    csv_content = <<~CSV
+      shipping_method,country,region,min_range_lbs,max_range_lbs,flat_rate,min_charge
+      Express Shipping,US,TX,0,10,9.99,5.00
       Express Shipping,US,TX,5,15,14.99,10.00
     CSV
 
@@ -568,6 +591,70 @@ class RateCsvImportServiceTest < ActiveSupport::TestCase
     ca_rates = @shipping_option.rates.where(country: "US", region: "CA")
     assert_equal 1, ca_rates.count
     assert_equal 10.00, ca_rates.first.flat_rate
+  end
+
+  test "should not affect rates belonging to a different company" do
+    other_company = companies(:globex)
+    other_option = other_company.shipping_options.create!(
+      name: "Express Shipping",
+      delivery_time: 5,
+      starting_rate: 5.0,
+      countries: [ "US" ],
+      status: "active"
+    )
+    other_rate = other_option.rates.create!(
+      country: "US", region: "CA", min_range_lbs: 0, max_range_lbs: 10,
+      flat_rate: 99.99, min_charge: 50.00
+    )
+
+    csv_content = <<~CSV
+      shipping_method,country,region,min_range_lbs,max_range_lbs,flat_rate,min_charge
+      Express Shipping,US,CA,0,10,12.99,6.00
+    CSV
+
+    file = create_csv_file(csv_content)
+    service = RateCsvImportService.new(company: @company, file: file)
+
+    result = service.call
+
+    assert result[:success]
+
+    # Other company's rate must be untouched
+    assert_equal 99.99, other_rate.reload.flat_rate
+  end
+
+  test "should replace existing rates when applying auto-corrections" do
+    @shipping_option.rates.create!(country: "US", region: "CA", min_range_lbs: 0, max_range_lbs: 10, flat_rate: 10.00, min_charge: 5.00)
+
+    # CSV with an oversized weight value that is auto-correctable
+    csv_content = <<~CSV
+      shipping_method,country,region,min_range_lbs,max_range_lbs,flat_rate,min_charge
+      Express Shipping,US,CA,0,99999,12.99,6.00
+    CSV
+
+    file = create_csv_file(csv_content)
+    service = RateCsvImportService.new(company: @company, file: file)
+
+    # First call without corrections — should report auto-correctable errors
+    result = service.call
+    assert_not result[:success]
+    assert result[:row_errors].any? { |e| e[:auto_correctable] }
+
+    # Re-read and call with corrections applied
+    file = create_csv_file(csv_content)
+    service = RateCsvImportService.new(company: @company, file: file)
+
+    result = service.call(apply_corrections: true)
+
+    assert result[:success]
+    assert_equal 1, result[:imported_count]
+    assert_equal 1, result[:replaced_count]
+
+    # Original rate should be replaced, corrected max_range should be 9999.9999
+    ca_rates = @shipping_option.rates.where(country: "US", region: "CA")
+    assert_equal 1, ca_rates.count
+    assert_equal 12.99, ca_rates.first.flat_rate
+    assert_equal BigDecimal("9999.9999"), ca_rates.first.max_range_lbs
   end
 
   test "success message includes replaced count when rates were replaced" do


### PR DESCRIPTION
## Summary
- CSV imports now **replace existing rates** for each `(shipping_method, country, region)` location included in the CSV, instead of failing on overlap conflicts
- Locations not present in the CSV remain completely untouched
- All operations (shipping option updates, rate deletions, new rate inserts) run in a single transaction — validation failures roll back everything cleanly, including deleted rates
- Success message reports how many existing rates were replaced
- Updated import UI instructions to explain the replace behavior

## Test plan
- [ ] Import CSV with rates for a location that already has rates — verify old rates are replaced with new ones
- [ ] Import CSV with rates for a new location — verify rates are created normally
- [ ] Import CSV with mix of existing and new locations — verify only matching locations are replaced
- [ ] Import CSV with validation errors — verify everything rolls back (original rates preserved)
- [ ] Import CSV with country-level rates (blank region) — verify they don't affect regional rates and vice versa
- [ ] Verify success flash message includes replaced count
- [ ] Run existing test suite to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)