### PR TITLE
Replace restcountries.com + hardcoded regions with Fluid API proxy

### DIFF
--- a/app/controllers/api/geography_controller.rb
+++ b/app/controllers/api/geography_controller.rb
@@ -1,0 +1,51 @@
+module Api
+  class GeographyController < ApplicationController
+    include DriAuthentication
+
+    COUNTRIES_CACHE_TTL = 6.hours
+    STATES_CACHE_TTL = 6.hours
+
+    def countries
+      countries = Rails.cache.fetch("fluid_countries", expires_in: COUNTRIES_CACHE_TTL) do
+        FluidClient.new.get("/api/countries")
+      end
+
+      render json: Array(countries).map { |c|
+        { value: c["iso"], label: "#{c["name"]} (#{c["iso"]})" }
+      }.sort_by { |c| c[:label] }
+    rescue FluidClient::Error, SocketError, Errno::ECONNREFUSED, Net::OpenTimeout => e
+      Rails.logger.error "[Geography] Failed to fetch countries: #{e.message}"
+      render json: [], status: :ok
+    end
+
+    def states
+      country_code = params[:country_code].to_s.strip.upcase
+      return render(json: []) if country_code.blank?
+
+      country_id = resolve_country_id(country_code)
+      return render(json: []) if country_id.nil?
+
+      states = Rails.cache.fetch("fluid_states_#{country_code}", expires_in: STATES_CACHE_TTL) do
+        FluidClient.new.get("/api/states", query: { country_id: country_id })
+      end
+
+      render json: Array(states).map { |s|
+        { value: s["name"], label: s["name"] }
+      }
+    rescue FluidClient::Error, SocketError, Errno::ECONNREFUSED, Net::OpenTimeout => e
+      Rails.logger.error "[Geography] Failed to fetch states for #{country_code}: #{e.message}"
+      render json: [], status: :ok
+    end
+
+  private
+
+    def resolve_country_id(country_code)
+      countries = Rails.cache.fetch("fluid_countries", expires_in: COUNTRIES_CACHE_TTL) do
+        FluidClient.new.get("/api/countries")
+      end
+
+      country = Array(countries).find { |c| c["iso"] == country_code }
+      country&.dig("id")
+    end
+  end
+end

--- a/app/views/rates/edit.html.erb
+++ b/app/views/rates/edit.html.erb
@@ -92,55 +92,34 @@
 
 <script>
 
-// Fallback function with hardcoded regions for major countries
-function getFallbackRegions(countryCode) {
-  const fallbackData = {
-    'US': ['Alabama', 'Alaska', 'Arizona', 'Arkansas', 'California', 'Colorado', 'Connecticut', 'Delaware', 'Florida', 'Georgia', 'Hawaii', 'Idaho', 'Illinois', 'Indiana', 'Iowa', 'Kansas', 'Kentucky', 'Louisiana', 'Maine', 'Maryland', 'Massachusetts', 'Michigan', 'Minnesota', 'Mississippi', 'Missouri', 'Montana', 'Nebraska', 'Nevada', 'New Hampshire', 'New Jersey', 'New Mexico', 'New York', 'North Carolina', 'North Dakota', 'Ohio', 'Oklahoma', 'Oregon', 'Pennsylvania', 'Rhode Island', 'South Carolina', 'South Dakota', 'Tennessee', 'Texas', 'Utah', 'Vermont', 'Virginia', 'Washington', 'West Virginia', 'Wisconsin', 'Wyoming'],
-    'AR': ['Buenos Aires', 'Catamarca', 'Chaco', 'Chubut', 'Córdoba', 'Corrientes', 'Entre Ríos', 'Formosa', 'Jujuy', 'La Pampa', 'La Rioja', 'Mendoza', 'Misiones', 'Neuquén', 'Río Negro', 'Salta', 'San Juan', 'San Luis', 'Santa Cruz', 'Santa Fe', 'Santiago del Estero', 'Tierra del Fuego', 'Tucumán'],
-    'CA': ['Alberta', 'British Columbia', 'Manitoba', 'New Brunswick', 'Newfoundland and Labrador', 'Northwest Territories', 'Nova Scotia', 'Nunavut', 'Ontario', 'Prince Edward Island', 'Quebec', 'Saskatchewan', 'Yukon'],
-    'MX': ['Aguascalientes', 'Baja California', 'Baja California Sur', 'Campeche', 'Chiapas', 'Chihuahua', 'Coahuila', 'Colima', 'Durango', 'Guanajuato', 'Guerrero', 'Hidalgo', 'Jalisco', 'México', 'Michoacán', 'Morelos', 'Nayarit', 'Nuevo León', 'Oaxaca', 'Puebla', 'Querétaro', 'Quintana Roo', 'San Luis Potosí', 'Sinaloa', 'Sonora', 'Tabasco', 'Tamaulipas', 'Tlaxcala', 'Veracruz', 'Yucatán', 'Zacatecas'],
-    'BR': ['Acre', 'Alagoas', 'Amapá', 'Amazonas', 'Bahia', 'Ceará', 'Distrito Federal', 'Espírito Santo', 'Goiás', 'Maranhão', 'Mato Grosso', 'Mato Grosso do Sul', 'Minas Gerais', 'Pará', 'Paraíba', 'Paraná', 'Pernambuco', 'Piauí', 'Rio de Janeiro', 'Rio Grande do Norte', 'Rio Grande do Sul', 'Rondônia', 'Roraima', 'Santa Catarina', 'São Paulo', 'Sergipe', 'Tocantins']
-  };
-  
-  return fallbackData[countryCode] || ['No regions available'];
-}
-
 // Function to load regions for a country
 function loadRegionsForCountry(countryCode, regionChoicesInstance, currentRegionValue = null) {
   if (!countryCode || !regionChoicesInstance) {
     console.error('Invalid parameters for loadRegionsForCountry');
     return;
   }
-  
-  
-  // Get regions from hardcoded data
-  const regions = getFallbackRegions(countryCode);
-  
-  const regionOptions = regions.map(region => ({
-    value: region,
-    label: region
-  }));
-  
-  // Clear existing choices first
-  try {
-    regionChoicesInstance.clearChoices();
-    
-    if (regionOptions.length > 0) {
-      // Set all region options at once (don't select first by default)
-      regionChoicesInstance.setChoices(regionOptions, 'value', 'label', false);
-      
-      // Set current region if provided
-      if (currentRegionValue) {
-        regionChoicesInstance.setChoiceByValue(currentRegionValue);
+
+  fetch(`/api/geography/states?country_code=${encodeURIComponent(countryCode)}`)
+    .then(response => response.json())
+    .then(regionOptions => {
+      try {
+        regionChoicesInstance.clearChoices();
+
+        if (regionOptions.length > 0) {
+          regionChoicesInstance.setChoices(regionOptions, 'value', 'label', false);
+
+          if (currentRegionValue) {
+            regionChoicesInstance.setChoiceByValue(currentRegionValue);
+          }
+        }
+      } catch (error) {
+        console.error('Error updating Choices:', error);
       }
-    } else {
-      // Set a placeholder option when no regions are available
-      regionChoicesInstance.setChoices([{ value: '', label: 'No regions available' }], 'value', 'label', false);
-    }
-    
-  } catch (error) {
-    console.error('Error updating Choices:', error);
-  }
+    })
+    .catch(error => {
+      console.error('Error loading regions:', error);
+      regionChoicesInstance.clearChoices();
+    });
 }
 
 // Function to initialize the form
@@ -186,14 +165,9 @@ function initializeRateEditForm() {
            setTimeout(() => {
 
            // Load countries from API
-           fetch('https://restcountries.com/v3.1/all?fields=name,cca2')
+           fetch('/api/geography/countries')
              .then(response => response.json())
-             .then(countries => {
-
-               const countryOptions = countries.map(country => ({
-                 value: country.cca2,
-                 label: `${country.name.common} (${country.cca2})`
-               }));
+             .then(countryOptions => {
 
 
                // Initialize Choices for countries

--- a/app/views/rates/new.html.erb
+++ b/app/views/rates/new.html.erb
@@ -128,14 +128,9 @@ function initializeRateNewForm() {
            setTimeout(() => {
 
            // Load countries data first, then initialize Choices
-           fetch('https://restcountries.com/v3.1/all?fields=name,cca2')
+           fetch('/api/geography/countries')
              .then(response => response.json())
-             .then(countries => {
-
-               const countryOptions = countries.map(country => ({
-                 value: country.cca2,
-                 label: `${country.name.common} (${country.cca2})`
-               })).sort((a, b) => a.label.localeCompare(b.label));
+             .then(countryOptions => {
 
 
                // Initialize Choices for countries
@@ -180,32 +175,18 @@ function initializeRateNewForm() {
             return;
           }
 
-
-          // Get regions from hardcoded data
-          const regions = getFallbackRegions(countryCode);
-
-          const regionOptions = regions.map(region => ({
-            value: region,
-            label: region
-          }));
-
-          // Clear existing choices and set new ones (don't select first by default)
-          regionChoicesInstance.clearChoices();
-          regionChoicesInstance.setChoices(regionOptions, 'value', 'label', false);
-
-        }
-
-        // Fallback function with hardcoded regions for major countries
-        function getFallbackRegions(countryCode) {
-          const fallbackData = {
-            'US': ['Alabama', 'Alaska', 'Arizona', 'Arkansas', 'California', 'Colorado', 'Connecticut', 'Delaware', 'Florida', 'Georgia', 'Hawaii', 'Idaho', 'Illinois', 'Indiana', 'Iowa', 'Kansas', 'Kentucky', 'Louisiana', 'Maine', 'Maryland', 'Massachusetts', 'Michigan', 'Minnesota', 'Mississippi', 'Missouri', 'Montana', 'Nebraska', 'Nevada', 'New Hampshire', 'New Jersey', 'New Mexico', 'New York', 'North Carolina', 'North Dakota', 'Ohio', 'Oklahoma', 'Oregon', 'Pennsylvania', 'Rhode Island', 'South Carolina', 'South Dakota', 'Tennessee', 'Texas', 'Utah', 'Vermont', 'Virginia', 'Washington', 'West Virginia', 'Wisconsin', 'Wyoming'],
-            'AR': ['Buenos Aires', 'Catamarca', 'Chaco', 'Chubut', 'Córdoba', 'Corrientes', 'Entre Ríos', 'Formosa', 'Jujuy', 'La Pampa', 'La Rioja', 'Mendoza', 'Misiones', 'Neuquén', 'Río Negro', 'Salta', 'San Juan', 'San Luis', 'Santa Cruz', 'Santa Fe', 'Santiago del Estero', 'Tierra del Fuego', 'Tucumán'],
-            'CA': ['Alberta', 'British Columbia', 'Manitoba', 'New Brunswick', 'Newfoundland and Labrador', 'Northwest Territories', 'Nova Scotia', 'Nunavut', 'Ontario', 'Prince Edward Island', 'Quebec', 'Saskatchewan', 'Yukon'],
-            'MX': ['Aguascalientes', 'Baja California', 'Baja California Sur', 'Campeche', 'Chiapas', 'Chihuahua', 'Coahuila', 'Colima', 'Durango', 'Guanajuato', 'Guerrero', 'Hidalgo', 'Jalisco', 'México', 'Michoacán', 'Morelos', 'Nayarit', 'Nuevo León', 'Oaxaca', 'Puebla', 'Querétaro', 'Quintana Roo', 'San Luis Potosí', 'Sinaloa', 'Sonora', 'Tabasco', 'Tamaulipas', 'Tlaxcala', 'Veracruz', 'Yucatán', 'Zacatecas'],
-            'BR': ['Acre', 'Alagoas', 'Amapá', 'Amazonas', 'Bahia', 'Ceará', 'Distrito Federal', 'Espírito Santo', 'Goiás', 'Maranhão', 'Mato Grosso', 'Mato Grosso do Sul', 'Minas Gerais', 'Pará', 'Paraíba', 'Paraná', 'Pernambuco', 'Piauí', 'Rio de Janeiro', 'Rio Grande do Norte', 'Rio Grande do Sul', 'Rondônia', 'Roraima', 'Santa Catarina', 'São Paulo', 'Sergipe', 'Tocantins']
-          };
-
-          return fallbackData[countryCode] || ['No regions available'];
+          fetch(`/api/geography/states?country_code=${encodeURIComponent(countryCode)}`)
+            .then(response => response.json())
+            .then(regionOptions => {
+              regionChoicesInstance.clearChoices();
+              if (regionOptions.length > 0) {
+                regionChoicesInstance.setChoices(regionOptions, 'value', 'label', false);
+              }
+            })
+            .catch(error => {
+              console.error('Error loading regions:', error);
+              regionChoicesInstance.clearChoices();
+            });
         }
       })
       .catch(error => {

--- a/app/views/shipping_options/edit.html.erb
+++ b/app/views/shipping_options/edit.html.erb
@@ -105,14 +105,9 @@ function initializeShippingEditForm() {
       const currentCountries = '<%= @shipping_option.countries.join(",") %>';
       
       // Load countries data
-      fetch('https://restcountries.com/v3.1/all?fields=name,cca2')
+      fetch('/api/geography/countries')
         .then(response => response.json())
-        .then(countries => {
-          
-          const countryOptions = countries.map(country => ({
-            value: country.cca2,
-            label: `${country.name.common} (${country.cca2})`
-          })).sort((a, b) => a.label.localeCompare(b.label));
+        .then(countryOptions => {
 
           
           // Check if Choices is available

--- a/app/views/shipping_options/new.html.erb
+++ b/app/views/shipping_options/new.html.erb
@@ -92,14 +92,9 @@ function initializeShippingNewForm() {
     }
     
     // Load countries data first, then initialize Choices
-    fetch('https://restcountries.com/v3.1/all?fields=name,cca2')
+    fetch('/api/geography/countries')
       .then(response => response.json())
-      .then(countries => {
-        
-        const countryOptions = countries.map(country => ({
-          value: country.cca2,
-          label: `${country.name.common} (${country.cca2})`
-        })).sort((a, b) => a.label.localeCompare(b.label));
+      .then(countryOptions => {
 
 
         // Initialize Choices for countries with options

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,8 @@ Rails.application.routes.draw do
         put :bulk_update
       end
     end
+    get "geography/countries", to: "geography#countries"
+    get "geography/states", to: "geography#states"
   end
 
   namespace :admin do

--- a/test/controllers/api/geography_controller_test.rb
+++ b/test/controllers/api/geography_controller_test.rb
@@ -1,0 +1,213 @@
+require "test_helper"
+
+class Api::GeographyControllerTest < ActionDispatch::IntegrationTest
+  fixtures :companies
+
+  setup do
+    @company = companies(:acme)
+    @dri = @company.droplet_installation_uuid
+
+    @mock_countries = [
+      { "id" => 1, "name" => "United States", "iso" => "US" },
+      { "id" => 2, "name" => "Canada", "iso" => "CA" },
+      { "id" => 3, "name" => "Philippines", "iso" => "PH" },
+    ]
+
+    @mock_states = [
+      { "id" => 10, "name" => "California", "country_id" => 1 },
+      { "id" => 11, "name" => "Texas", "country_id" => 1 },
+    ]
+
+    Rails.cache.clear
+  end
+
+  # ============================================
+  # GET /api/geography/countries
+  # ============================================
+
+  test "countries returns expected format" do
+    stub_fluid_client(countries: @mock_countries) do
+      get api_geography_countries_url, params: { dri: @dri }
+    end
+
+    assert_response :success
+    json = JSON.parse(response.body)
+
+    assert_equal 3, json.length
+    first = json.first
+    assert first.key?("value")
+    assert first.key?("label")
+    assert_not first.key?("id")
+  end
+
+  test "countries are sorted by label" do
+    stub_fluid_client(countries: @mock_countries) do
+      get api_geography_countries_url, params: { dri: @dri }
+    end
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    labels = json.map { |c| c["label"] }
+
+    assert_equal labels.sort, labels
+  end
+
+  test "countries returns label with ISO code in parens" do
+    stub_fluid_client(countries: @mock_countries) do
+      get api_geography_countries_url, params: { dri: @dri }
+    end
+
+    assert_response :success
+    json = JSON.parse(response.body)
+
+    us = json.find { |c| c["value"] == "US" }
+    assert_equal "United States (US)", us["label"]
+  end
+
+  test "countries without DRI returns error" do
+    get api_geography_countries_url
+
+    assert_response :not_found
+  end
+
+  test "countries returns empty array on FluidClient error" do
+    client = stub_client_that_raises(FluidClient::APIError.new("Server error"))
+
+    FluidClient.stub(:new, client) do
+      get api_geography_countries_url, params: { dri: @dri }
+    end
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert_equal [], json
+  end
+
+  test "countries caches FluidClient response" do
+    call_count = 0
+    fake_client = lambda_client do |path, _opts|
+      if path == "/api/countries"
+        call_count += 1
+        @mock_countries
+      end
+    end
+
+    # Test env uses :null_store, swap in memory store to verify caching
+    original_cache = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+
+    FluidClient.stub(:new, fake_client) do
+      get api_geography_countries_url, params: { dri: @dri }
+      assert_response :success
+
+      get api_geography_countries_url, params: { dri: @dri }
+      assert_response :success
+    end
+
+    assert_equal 1, call_count, "FluidClient should only be called once due to caching"
+  ensure
+    Rails.cache = original_cache
+  end
+
+  # ============================================
+  # GET /api/geography/states
+  # ============================================
+
+  test "states returns full state names" do
+    stub_fluid_client(countries: @mock_countries, states: { 1 => @mock_states }) do
+      get api_geography_states_url, params: { dri: @dri, country_code: "US" }
+    end
+
+    assert_response :success
+    json = JSON.parse(response.body)
+
+    assert_equal 2, json.length
+    assert_equal "California", json.first["value"]
+    assert_equal "California", json.first["label"]
+  end
+
+  test "states with missing country_code returns empty array" do
+    get api_geography_states_url, params: { dri: @dri }
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert_equal [], json
+  end
+
+  test "states with unknown country_code returns empty array" do
+    stub_fluid_client(countries: @mock_countries) do
+      get api_geography_states_url, params: { dri: @dri, country_code: "ZZ" }
+    end
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert_equal [], json
+  end
+
+  test "states without DRI returns error" do
+    get api_geography_states_url, params: { country_code: "US" }
+
+    assert_response :not_found
+  end
+
+  test "states returns empty array on FluidClient error" do
+    call_count = 0
+    fake_client = lambda_client do |path, opts|
+      call_count += 1
+      if path == "/api/countries"
+        @mock_countries
+      else
+        raise FluidClient::APIError, "Server error"
+      end
+    end
+
+    FluidClient.stub(:new, fake_client) do
+      get api_geography_states_url, params: { dri: @dri, country_code: "US" }
+    end
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert_equal [], json
+  end
+
+  test "states normalizes country_code to uppercase" do
+    stub_fluid_client(countries: @mock_countries, states: { 1 => @mock_states }) do
+      get api_geography_states_url, params: { dri: @dri, country_code: "us" }
+    end
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert_equal 2, json.length
+  end
+
+private
+
+  # Creates a fake client object that delegates get() to a block
+  def lambda_client(&block)
+    client = Object.new
+    client.define_singleton_method(:get) do |path, opts = {}|
+      block.call(path, opts)
+    end
+    client
+  end
+
+  # Raises on any get() call
+  def stub_client_that_raises(error)
+    lambda_client { |_path, _opts| raise error }
+  end
+
+  # Stubs FluidClient with preconfigured responses for countries and states
+  # states should be a hash of { country_id => states_array }
+  def stub_fluid_client(countries: [], states: {}, &block)
+    fake = lambda_client do |path, opts|
+      case path
+      when "/api/countries"
+        countries
+      when "/api/states"
+        country_id = opts.dig(:query, :country_id)
+        states[country_id] || []
+      end
+    end
+
+    FluidClient.stub(:new, fake, &block)
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `Api::GeographyController` with two proxy endpoints (`/api/geography/countries`, `/api/geography/states?country_code=XX`) that call Fluid's `/api/countries` and `/api/states` APIs
- Replaces client-side `restcountries.com` dependency and hardcoded region data (previously only US, CA, MX, BR, AR) with server-side Fluid API calls that have worldwide coverage
- Countries like the Philippines now return regions (17 regions) where before they got nothing
- Responses are cached for 6 hours via `Rails.cache`; network errors return `[]` gracefully instead of 500s

## Changes

| File | What changed |
|---|---|
| `app/controllers/api/geography_controller.rb` | **New** — two actions with DRI auth, caching, ISO-to-ID resolution |
| `config/routes.rb` | Two new routes in `namespace :api` |
| `app/views/shipping_options/new.html.erb` | Replaced restcountries.com fetch with `/api/geography/countries` |
| `app/views/shipping_options/edit.html.erb` | Same |
| `app/views/rates/new.html.erb` | Replaced country fetch + replaced hardcoded `loadRegionsForCountry`/`getFallbackRegions` with `/api/geography/states` fetch |
| `app/views/rates/edit.html.erb` | Same |
| `test/controllers/api/geography_controller_test.rb` | **New** — 12 tests |

## Test plan

- [x] 12 controller tests pass (format, sorting, DRI auth, caching, error handling, edge cases)
- [x] Full test suite passes (303 tests, 0 failures)
- [x] RuboCop clean
- [x] Manual curl test: countries returns 227 countries sorted alphabetically
- [x] Manual curl test: US states returns 51 states with full names
- [x] Manual curl test: Philippines returns 17 regions (previously zero)
- [x] Manual curl test: lowercase `country_code=us` normalizes correctly
- [x] Manual curl test: unknown country `ZZ` returns `[]`
- [x] Manual curl test: missing `country_code` returns `[]`
- [x] Manual curl test: missing DRI returns 404 error
- [ ] Browser test: navigate to rates/new, select Philippines, verify region dropdown populates
- [ ] Browser test: navigate to shipping_options/new, verify country dropdown populates

🤖 Generated with [Claude Code](https://claude.com/claude-code)