### PR TITLE
Add freetds-dev to base Docker image - STU2-1333

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -12,6 +12,7 @@ RUN apt-get update -qq && \
     libvips \
     node-gyp \
     libpq-dev \
+    freetds-dev \
     pkg-config \
     libyaml-dev \
     libjemalloc2 \


### PR DESCRIPTION
## Summary

- Adds `freetds-dev` to the `apt-get install` step in `docker/Dockerfile.base`
- The `tiny_tds` gem requires FreeTDS headers (`sybfront.h`) to compile its native extension; without them `bundle install` fails with `Can't find the 'sybfront.h' header`

## Test plan
- [ ] Docker build completes without errors on the next CI run
- [ ] `bundle install` installs `tiny_tds` successfully inside the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)