### PR TITLE
Add libct4 runtime library for tiny_tds - STU2-1211

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /rails
 
 # Install base packages
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y curl libjemalloc2 libvips postgresql-client && \
+    apt-get install --no-install-recommends -y curl libct4 libjemalloc2 libvips postgresql-client && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Set production environment


### PR DESCRIPTION
## Summary
- Adds `libct4` to the base stage apt-get install in `docker/Dockerfile`

`tiny_tds` compiles against `freetds-dev` (build stage) but needs `libct.so.4` at runtime. Without `libct4` in the final image, Rails crashes on boot when trying to load the native extension, causing both the migration job and app startup to fail.

## Test plan
- [ ] Verify migration job runs without errors after deploy
- [ ] Verify app boots successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)