### PR TITLE
Add complete freetds runtime deps for tiny_tds - STU2-1211

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,8 +6,15 @@ WORKDIR /rails
 
 # Install base packages
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y curl libct4 libjemalloc2 libvips postgresql-client && \
-    rm -rf /var/lib/apt/lists /var/cache/apt/archives
+    apt-get install --no-install-recommends -y \
+      curl \
+      freetds-common \
+      libct4 \
+      libsybdb5 \
+      libjemalloc2 \
+      libvips \
+      postgresql-client \
+    && rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Set production environment
 ENV RAILS_ENV="production" \


### PR DESCRIPTION
## Summary
Adds the full set of FreeTDS runtime libraries to the base stage:
- `libsybdb5` — the shared library `tiny_tds.so` actually links against (`libsybdb.so.5`)
- `libct4` — CT-Library runtime
- `freetds-common` — shared FreeTDS config files

## Root cause
Previous PRs (#46, #47) added `freetds-dev` to the build stage (compilation works) and `libct4` to the base stage, but `tiny_tds` on this Debian version links against `libsybdb.so.5` not `libct.so.4`. Without `libsybdb5` the app crashes on boot: `libsybdb.so.5: cannot open shared object file`.

## Test plan
- [ ] Docker build succeeds
- [ ] Migration job completes without errors
- [ ] App boots successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)