### PR TITLE
Hide shipping options when no rate matches customer location

### DIFF
--- a/test/services/shipping_calculation_service_country_level_test.rb
+++ b/test/services/shipping_calculation_service_country_level_test.rb
@@ -157,7 +157,7 @@ class ShippingCalculationServiceCountryLevelTest < ActiveSupport::TestCase
     assert_equal 14.99, express_option[:shipping_total]
   end
 
-  test "should use starting_rate when neither region-specific nor country-level rate matches" do
+  test "should exclude shipping option when neither region-specific nor country-level rate matches" do
     # Create rate for different country
     @shipping_option.rates.create!(
       country: "CA",
@@ -178,10 +178,9 @@ class ShippingCalculationServiceCountryLevelTest < ActiveSupport::TestCase
     result = service.call
 
     assert result[:success]
-    # Should use shipping_option's starting_rate since no matching rate
+    # Should not include shipping option since no matching rate for US
     express_option = result[:shipping_options].find { |opt| opt[:shipping_title] == "Express Shipping" }
-    assert_not_nil express_option
-    assert_equal 15.99, express_option[:shipping_total]
+    assert_nil express_option
   end
 
   test "rate_matches_location_exact should only match when region is present and matches" do

--- a/test/services/shipping_calculation_service_test.rb
+++ b/test/services/shipping_calculation_service_test.rb
@@ -95,16 +95,24 @@ class ShippingCalculationServiceTest < ActiveSupport::TestCase
     assert_equal 15.99, express_option[:shipping_total]
   end
 
-  test "should use starting_rate when no specific rate exists" do
+  test "should exclude shipping option when no matching rate exists" do
     result = @service.call
 
     assert result[:success]
     express_option = result[:shipping_options].find { |opt| opt[:shipping_title] == "Express Shipping" }
-    assert_not_nil express_option
-    assert_equal 15.99, express_option[:shipping_total]
+    assert_nil express_option
   end
 
   test "should format delivery time correctly" do
+    @shipping_option.rates.create!(
+      country: "US",
+      region: "CA",
+      min_range_lbs: 0,
+      max_range_lbs: 100,
+      flat_rate: 10.00,
+      min_charge: 0
+    )
+
     result = @service.call
 
     assert result[:success]


### PR DESCRIPTION
## Summary

- When no rate matched a customer's location (neither region-specific nor country-level), the service was falling back to `shipping_option.starting_rate` and still displaying the option at checkout. This caused shipping methods like "Standard USPS" (configured only for US territories like GU, PR, VI) to incorrectly appear for all US states.
- Now `serialize_shipping_option` returns `nil` when `find_best_rate` finds no match, and `success_result` uses `filter_map` to exclude those options from the response.

## Test plan

- [ ] Checkout from a US state (e.g. UT) with a shipping method that only has rates for territories — should NOT appear in shipping options
- [ ] Checkout from a territory (e.g. GU) for that same method — should still appear with correct pricing
- [ ] Checkout with methods that have proper state-level or country-level (region=nil) rates — should continue working normally
- [ ] Verify "Coordinate with the shop" default still shows when zero shipping options have matching rates

🤖 Generated with [Claude Code](https://claude.com/claude-code)