### PR TITLE
Remove Azure SQL Server hostname restriction for Exigo connection - STU2-1211

### DIFF
--- a/app/controllers/exigo_settings_controller.rb
+++ b/app/controllers/exigo_settings_controller.rb
@@ -4,10 +4,6 @@ class ExigoSettingsController < ApplicationController
   include DriAuthentication
 
 
-  ALLOWED_SERVER_PATTERN = /\A[a-z0-9]([a-z0-9\-]*[a-z0-9])?
-                             (\.[a-z0-9]([a-z0-9\-]*[a-z0-9])?)*
-                             \.database\.windows\.net\z/ix.freeze
-
   def edit; end
 
   def update
@@ -30,13 +26,6 @@ class ExigoSettingsController < ApplicationController
 
     if server.blank? || database.blank? || user.blank? || password.blank?
       render json: { success: false, error: "All fields are required" }, status: :bad_request
-      return
-    end
-
-    unless server.match?(ALLOWED_SERVER_PATTERN)
-      render json: { success: false,
-                     error: "Invalid server hostname. Must be an Azure SQL Server address (*.database.windows.net)", },
-             status: :bad_request
       return
     end
 


### PR DESCRIPTION
## Summary
- Removes the `ALLOWED_SERVER_PATTERN` regex that restricted Exigo DB server hostnames to `*.database.windows.net` only
- Allows connecting to any SQL Server hostname, not just Azure SQL

## Test plan
- [x] Go to Exigo Settings and test connection with a non-Azure SQL Server hostname
- [x] Verify connection succeeds if credentials are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)