### PR TITLE
Add azure: true to TinyTds connections for Azure SQL compatibility - STU2-1478

### DIFF
--- a/app/controllers/exigo_settings_controller.rb
+++ b/app/controllers/exigo_settings_controller.rb
@@ -36,7 +36,8 @@ class ExigoSettingsController < ApplicationController
         username: user,
         password: password,
         timeout: 5,
-        connect_timeout: 5
+        connect_timeout: 5,
+        azure: true
       )
 
       # Execute a simple query to verify the connection works

--- a/app/services/exigo_subscription_service.rb
+++ b/app/services/exigo_subscription_service.rb
@@ -70,7 +70,8 @@ private
       username: @company.settings["exigo_db_user"],
       password: @company.settings["exigo_db_password"],
       timeout: 5,
-      connect_timeout: 5
+      connect_timeout: 5,
+      azure: true
     )
   end
 


### PR DESCRIPTION
## Summary
- Adds `azure: true` flag to TinyTds client connections in both `ExigoSettingsController#test_connection` and `ExigoSubscriptionService#build_client`
- Exigo databases are hosted on Azure SQL Server, which requires this flag for proper authentication
- Without it, connections fail with "Login failed" errors (422)

## Test plan
- [ ] Test connection to Exigo sandbox from admin settings
- [ ] Test connection to Exigo production from admin settings
- [ ] Verify subscription check works correctly after login during checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)