### PR TITLE
Enable encrypted TinyTds connections for Exigo compatibility - STU2-1478

### DIFF
--- a/app/controllers/exigo_settings_controller.rb
+++ b/app/controllers/exigo_settings_controller.rb
@@ -35,6 +35,9 @@ class ExigoSettingsController < ApplicationController
         database: database,
         username: user,
         password: password,
+        port: 1433,
+        tds_version: "7.3",
+        azure: true,
         timeout: 5,
         connect_timeout: 5
       )

--- a/app/services/exigo_subscription_service.rb
+++ b/app/services/exigo_subscription_service.rb
@@ -69,6 +69,9 @@ private
       database: @company.settings["exigo_db_name"],
       username: @company.settings["exigo_db_user"],
       password: @company.settings["exigo_db_password"],
+      port: 1433,
+      tds_version: "7.3",
+      azure: true,
       timeout: 5,
       connect_timeout: 5
     )

--- a/config/initializers/tiny_tds.rb
+++ b/config/initializers/tiny_tds.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Prevent TinyTds from appending @hostname to the username when azure: true.
+# Azure mode enables encryption (required for Exigo sandbox), but the default
+# username mangling breaks authentication for non-Azure-hosted SQL Servers
+# like sandbox.bi.exigo.com.
+TinyTds::Client.class_eval do
+  private
+
+  alias_method :original_parse_username, :parse_username
+
+  def parse_username(opts)
+    opts[:username]
+  end
+end

--- a/config/initializers/tiny_tds.rb
+++ b/config/initializers/tiny_tds.rb
@@ -5,7 +5,7 @@
 # username mangling breaks authentication for non-Azure-hosted SQL Servers
 # like sandbox.bi.exigo.com.
 TinyTds::Client.class_eval do
-  private
+private
 
   alias_method :original_parse_username, :parse_username
 


### PR DESCRIPTION
## Summary
- Adds `azure: true`, `port: 1433`, and `tds_version: "7.3"` to TinyTds connections for Exigo SQL Server encryption support
- Adds initializer monkey-patch to prevent TinyTds from appending `@hostname` to the username (which breaks auth for hosts like `sandbox.bi.exigo.com`)
- Tested successfully with both production and sandbox Exigo credentials

## Test plan
- [x] Test connection to Exigo sandbox from `rails c`
- [x] Test connection to Exigo production from `rails c`
- [ ] Test connection from admin settings UI (test_connection)
- [ ] Verify subscription check works during checkout login

🤖 Generated with [Claude Code](https://claude.com/claude-code)