### PR TITLE
Show free_for_subscribers options without requiring rate match -STU2-1211

### DIFF
--- a/app/services/shipping_calculation_service.rb
+++ b/app/services/shipping_calculation_service.rb
@@ -137,17 +137,19 @@ private
   end
 
   def serialize_shipping_option(shipping_option)
+    if shipping_option.free_for_subscribers? && user_has_active_subscription?
+      return {
+        shipping_total: 0,
+        shipping_title: shipping_option.name,
+        shipping_delivery_time_estimate: format_delivery_time(shipping_option.delivery_time),
+      }
+    end
+
     rate = find_best_rate(shipping_option)
     return nil unless rate
 
-    final_total = if shipping_option.free_for_subscribers? && user_has_active_subscription?
-      0
-    else
-      [ rate.flat_rate, rate.min_charge ].max
-    end
-
     {
-      shipping_total: final_total,
+      shipping_total: [ rate.flat_rate, rate.min_charge ].max,
       shipping_title: shipping_option.name,
       shipping_delivery_time_estimate: format_delivery_time(shipping_option.delivery_time),
     }


### PR DESCRIPTION
## Summary
- Subscriber-only shipping options (e.g. Yoli+ FREE Shipping) are always $0 regardless of cart weight
- Previously these options were filtered out when `find_best_rate` returned nil (no rate matching the weight range)
- Now they return immediately with $0 without needing a rate match when the user has an active subscription

## Test plan
- [ ] Login with subscriber account → "Yoli+ FREE Shipping" should appear as an option with $0
- [ ] Non-subscriber should NOT see the option
- [ ] Normal shipping options (Standard, Priority, Expedited) still calculate rates normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)